### PR TITLE
Minesweep. The que can now consume 10x more or drop when overfed.

### DIFF
--- a/maps/minesweeper/main.lua
+++ b/maps/minesweeper/main.lua
@@ -201,6 +201,9 @@ local function visit_cell(position)
 
     if cell then
         if cell[1] == 10 then
+	        -- somehow there is a race possible here.
+	        -- cf this -1 screenie https://discord.com/channels/433039858794233858/832822538634526740/838160964175265813
+	        -- this CAN happen if there are 2 checks same tick, but that would mean the event + que? idk but -1 is only here.
             Functions.kaboom(position)
             score_change = -8
             cell[1] = -1

--- a/maps/minesweeper/main.lua
+++ b/maps/minesweeper/main.lua
@@ -591,10 +591,14 @@ local function on_entity_died(event)
 end
 
 local function on_nth_tick()
+    local threshold = 10 -- 6-10 max on a full que pls; 25 is the frezing max prob.
     for k, position in pairs(minesweeper.visit_queue) do
         visit_cell(position)
         table.remove(minesweeper.visit_queue, k)
-        break
+        threshold = threshold - 1
+        if threshold == 0 then
+            break
+        end
     end
 end
 

--- a/maps/minesweeper/main.lua
+++ b/maps/minesweeper/main.lua
@@ -211,6 +211,7 @@ local function visit_cell(position)
                 local p = {x = position.x + vector[1], y = position.y + vector[2]}
                 local key = Functions.position_to_string(p)
                 if minesweeper.cells[key] and minesweeper.cells[key][1] < 10 then
+					-- is duplicate insertion possible here? For the one that is in the que already
                     table.insert(minesweeper.visit_queue, {x = p.x, y = p.y})
                 end
             end
@@ -245,6 +246,7 @@ local function visit_cell(position)
                 adjacent_cell[1] = mine_count
                 update_rendering(adjacent_cell, adjacent_position)
                 if mine_count == 0 then
+                    -- is duplicate insertion possible here? For the one that is in the que already
                     table.insert(minesweeper.visit_queue, {x = adjacent_position.x, y = adjacent_position.y})
                 end
             end
@@ -260,6 +262,7 @@ local function visit_cell(position)
             local adjacent_key = Functions.position_to_string(adjacent_position)
             local adjacent_cell = minesweeper.cells[adjacent_key]
             if adjacent_cell and adjacent_cell[1] < 9 then
+                -- is duplicate insertion possible here? For the one that is in the que already
                 table.insert(minesweeper.visit_queue, {x = adjacent_position.x, y = adjacent_position.y})
             end
         end
@@ -370,6 +373,7 @@ local function mark_mine(entity, player)
             -- this is a second point that might lead to races and score -1. The first one is at the usual kaboom.
             minesweeper.cells[key][1] = -1
             solve_attempt(p)
+            -- is duplicate insertion possible here? For the one that is in the que already
             table.insert(minesweeper.visit_queue, {x = p.x, y = p.y})
         end
     end

--- a/maps/minesweeper/main.lua
+++ b/maps/minesweeper/main.lua
@@ -201,9 +201,9 @@ local function visit_cell(position)
 
     if cell then
         if cell[1] == 10 then
-	        -- somehow there is a race possible here.
-	        -- cf this -1 screenie https://discord.com/channels/433039858794233858/832822538634526740/838160964175265813
-	        -- this CAN happen if there are 2 checks same tick, but that would mean the event + que? idk but -1 is only here.
+            -- somehow there is a race possible here.
+            -- cf this -1 screenie https://discord.com/channels/433039858794233858/832822538634526740/838160964175265813
+            -- this CAN happen if there are 2 checks same tick, but that would mean the event + que? idk but -1 is only here.
             Functions.kaboom(position)
             score_change = -8
             cell[1] = -1

--- a/maps/minesweeper/main.lua
+++ b/maps/minesweeper/main.lua
@@ -591,6 +591,17 @@ local function on_entity_died(event)
 end
 
 local function on_nth_tick()
+    -- that part is a shortcut that tryes to fix at least something
+    -- each 2 ticks x 10 per call is *just* 300 ops a sec
+    -- however it lags for me on a full que (K). if it is more than 30 sec of small lags I want to drop the table :>
+    if #minesweeper.visit_queue > 9000
+        -- this should only kill "numbers" render afaics
+        -- all the other states *should* go fine
+        minesweeper.visit_queue = {}
+        -- @XXX: add a better log/message that is more eco friendly.
+        game.print("[dbg] (You should NOT see this. Unless a big event went nuts again) The que is over 9000! Tell devs we've dropped some of it. Pls walk on numbers on the ground in case they were dropped and have not been updated yet.")
+    end
+    
     local threshold = 10 -- 6-10 max on a full que pls; 25 is the frezing max prob.
     for k, position in pairs(minesweeper.visit_queue) do
         visit_cell(position)

--- a/maps/minesweeper/main.lua
+++ b/maps/minesweeper/main.lua
@@ -367,6 +367,7 @@ local function mark_mine(entity, player)
         if minesweeper.cells[key] and minesweeper.cells[key][1] == 10 then
             Functions.kaboom(p)
             score_change = score_change - 8
+            -- this is a second point that might lead to races and score -1. The first one is at the usual kaboom.
             minesweeper.cells[key][1] = -1
             solve_attempt(p)
             table.insert(minesweeper.visit_queue, {x = p.x, y = p.y})


### PR DESCRIPTION
Some comments added around;
This eat 10 things part for the que introduced
and the drop_me part as well.

The last one introduces a # on the que check on each 2 ticks though... we can probably move it under `tick % 300 == 0` or smth if it IS expensive (idk really the scale it would take)
In a grand scheme the que should be put aside to a stash and not just be dropped prob. Alas who cares, just walk over these again.

The 60k+ que save with these changes baked in revives auto-0es with a spike (prob due to the garbage collector?). Works fine with SP afterwards.