### PR TITLE
Fix nil bug - Fancy Time

### DIFF
--- a/tools/fancy_time.lua
+++ b/tools/fancy_time.lua
@@ -105,6 +105,9 @@ function Public.filter_time(fancy_array, filter_words, mode)
 			end
 		end
 	end
+	if #filtered_array == 0 then
+        	filtered_array = fancy_array
+  	end
 	return filtered_array
 end
 
@@ -124,9 +127,7 @@ end
 ---@param seconds <number>
 function Public.short_fancy_time(seconds)
 	local fancy = Public.seconds_to_fancy(seconds,true)
-	if seconds > 59 then
-		fancy = Public.filter_time(fancy, {"seconds","s"}, false)
-	end
+	fancy = Public.filter_time(fancy, {"seconds","s"}, false)
 	fancy = Public.fancy_time_formatting(fancy)
 	return fancy
 end

--- a/tools/fancy_time.lua
+++ b/tools/fancy_time.lua
@@ -124,7 +124,9 @@ end
 ---@param seconds <number>
 function Public.short_fancy_time(seconds)
 	local fancy = Public.seconds_to_fancy(seconds,true)
-	fancy = Public.filter_time(fancy, {"seconds","s"}, false)
+	if seconds > 59 then
+		fancy = Public.filter_time(fancy, {"seconds","s"}, false)
+	end
 	fancy = Public.fancy_time_formatting(fancy)
 	return fancy
 end


### PR DESCRIPTION
Values below 60 seconds were returning nil in short_fancy_time()
Filter removed seconds, resulting values was empty (nil)