### PR TITLE
Update

### DIFF
--- a/maps/journey/constants.lua
+++ b/maps/journey/constants.lua
@@ -44,6 +44,12 @@ Public.world_selector_colors = {
 	[3] = {r = 200, g = 100, b = 100, a = 255},
 }
 
+Public.reroll_selector_area_color = {r = 220, g = 220, b = 220, a = 255}
+Public.reroll_selector_area = {
+	left_top = {x = -4, y = math.floor(Public.mothership_radius - 6) * -1},
+	right_bottom = {x = 4, y = math.floor(Public.mothership_radius - 6) * -1 + 5},
+}
+
 Public.mothership_messages = {
 	waiting = {
 		"Return to me, so we can continue the journey!",
@@ -76,25 +82,26 @@ Public.mothership_gen_settings = {
 }
 
 Public.modifiers = {	
-	["trees"] = {-30, -15, "Trees"},
+	["trees"] = {-20, -10, "Trees"},
 	["tree_durability"] = {-30, -15, "Tree Durability"},
 	["cliff_settings"] = {20, 40, "Cliffs"},	
-	["water"] = {-30, -15, "Water"},
+	["water"] = {-20, -10, "Water"},
 	["coal"] = {-20, -10, "Coal"},
 	["stone"] = {-20, -10, "Stone"},
 	["iron-ore"] = {-20, -10, "Iron Ore"},
 	["copper-ore"] = {-20, -10, "Copper Ore"},
 	["crude-oil"] = {-20, -10, "Oil"},
 	["uranium-ore"] = {-20, -10, "Uranium Ore"},
-	["enemy-base"] = {20, 40, "Nests"},
-	["expansion_cooldown"] = {-40, -20, "Nest Expansion Cooldown"},
-	["enemy_attack_pollution_consumption_modifier"] = {-30, -15, "Nest Pollution Consumption"},
+	["mixed_ore"] = {-20, -10, "Mixed Ore"},
+	["enemy-base"] = {10, 20, "Nests"},
+	["expansion_cooldown"] = {-30, -15, "Nest Expansion Cooldown"},
+	["enemy_attack_pollution_consumption_modifier"] = {-20, -10, "Nest Pollution Consumption"},
 	["max_unit_group_size"] = {15, 30, "Biter Group Size Maximum"},	
-	["time_factor"] = {20, 40, "Evolution Time Factor"},
-	["destroy_factor"] = {20, 40, "Evolution Destroy Factor"},
-	["pollution_factor"] = {20, 40, "Evolution Pollution Factor"},	
-	["ageing"] = {-30, -15, "Terrain Pollution Consumption"},
-	["diffusion_ratio"] = {15, 30, "Pollution Diffusion"},
+	["time_factor"] = {15, 30, "Evolution Time Factor"},
+	["destroy_factor"] = {15, 30, "Evolution Destroy Factor"},
+	["pollution_factor"] = {15, 30, "Evolution Pollution Factor"},	
+	["ageing"] = {-20, -10, "Terrain Pollution Consumption"},
+	["diffusion_ratio"] = {10, 20, "Pollution Diffusion"},
 	["technology_price_multiplier"] = {10, 20, "Technology Price"},	
 }
 
@@ -151,27 +158,27 @@ Public.build_type_whitelist = {
 }
 
 Public.unique_world_traits = {	
-	["lush"] = {"Lush", "Pure Vanilla."},
+	["lush"] = {"Lush", "Pure Vanilla."},	
+	["eternal_night"] = {"Eternal Night", "This world seems to be missing a sun."},
+	["dense_atmosphere"] = {"Dense Atmosphere", "Your roboport structures seem to malfunction."},
+	["pitch_black"] = {"Pitch Black", "No light may reach this realm."},
+	["volcanic"] = {"Volcanic", "The floor is (almost) lava."},
 	["matter_anomaly"] = {"Matter Anomaly", "Why can't i hold all these ores."},
 	["mountainous"] = {"Mountainous", "Diggy diggy hole!"},
-	["quantum_anomaly"] = {"Quantum Anomaly", "Research complete."},
-	["pitch_black"] = {"Pitch Black", "No light may reach this realm."},
+	["quantum_anomaly"] = {"Quantum Anomaly", "Research complete."},	
 	["replicant_fauna"] = {"Replicant Fauna", "The biters feed on your structures."},
 	["tarball"] = {"Tarball", "Door stuck, Door stuck..."},
-	["swamps"] = {"Swamps", "No deep water to be found in this world."},
-	["volcanic"] = {"Volcanic", "The floor is (almost) lava."},
+	["swamps"] = {"Swamps", "No deep water to be found in this world."},	
 	["chaotic_resources"] = {"Chaotic Resources", "Something to sort out."},
 	["infested"] = {"Infested", "They lurk inside."},
-	["low_mass"] = {"Low Mass", "You feel light footed and the robots are buzzing."},
-	["eternal_night"] = {"Eternal Night", "This world seems to be missing a sun."},
-	["eternal_day"] = {"Eternal Day", "The sun never moves."},
-	["dense_atmosphere"] = {"Dense Atmosphere", "The roboports seem to malfunction."},
+	["low_mass"] = {"Low Mass", "You feel light footed and the robots are buzzing."},	
+	["eternal_day"] = {"Eternal Day", "The sun never moves."},	
 	["undead_plague"] = {"Undead Plague", "The dead are restless."},
+	--[[
+	]]
 	
-	--["snowpiercer"] = {"Snowpiercer", "It's cold outside, so very cold."},
 	--["wasteland"] = {"Wasteland", "Smells like sulfur."},
 	--["wetlands"] = {"Wetlands", "Many rivers and many fish."},
-	--["high_mass"] = {"High Mass", "Your feet will need some proper ground to walk well."},
 }
 
 return Public

--- a/maps/journey/unique_modifiers.lua
+++ b/maps/journey/unique_modifiers.lua
@@ -41,8 +41,10 @@ Public.lush = {}
 
 Public.eternal_night = {
 	on_world_start = function(journey)
-		game.surfaces.nauvis.daytime = 0.5
-		game.surfaces.nauvis.freeze_daytime = true
+		local surface = game.surfaces.nauvis
+		surface.daytime = 0.44
+		surface.freeze_daytime = true
+		surface.solar_power_multiplier = 5
 	end,
 }
 
@@ -76,7 +78,7 @@ Public.mountainous = {
 		local surface = entity.surface
 		event.buffer.clear()
 		local ore = ore_raffle[math_random(1, size_of_ore_raffle)]
-		local count = math_floor(math_sqrt(entity.position.x ^ 2 + entity.position.y ^ 2) * 0.02) + math_random(25, 75)
+		local count = math_floor(math_sqrt(entity.position.x ^ 2 + entity.position.y ^ 2) * 0.05) + math_random(25, 75)
 		local ore_amount = math_floor(count * 0.85)
 		local stone_amount = math_floor(count * 0.15)
 		surface.spill_item_stack(entity.position, {name = ore, count = ore_amount}, true)
@@ -120,10 +122,11 @@ Public.replicant_fauna = {
 Public.pitch_black = {
 	on_world_start = function(journey)
 		local surface = game.surfaces.nauvis
-		surface.daytime = 0.5
+		surface.daytime = 0.44
 		surface.freeze_daytime = true
+		surface.solar_power_multiplier = 3
 		surface.min_brightness = 0
-		surface.brightness_visual_weights = {1, 1, 1, 1}
+		surface.brightness_visual_weights = {0.8, 0.8, 0.8, 1}
 	end,
 }
 
@@ -194,7 +197,7 @@ Public.volcanic = {
 				y_scale = 32,
 				target = event.area.left_top,
 				surface = event.surface,
-				tint = {r = 0.55, g = 0.0, b = 0.0, a = 0.5},
+				tint = {r = 0.55, g = 0.0, b = 0.0, a = 0.25},
 				render_layer = 'ground'
 		}))
 	end,
@@ -211,6 +214,13 @@ Public.volcanic = {
 		surface.request_to_generate_chunks({x = 0, y = 0}, 3)
 		surface.force_generate_chunk_requests()
 		surface.spill_item_stack({0, 0}, {name = "stone-brick", count = 4096}, true)
+		for x = -24, 24, 1 do
+			for y = -24, 24, 1 do
+				if math.sqrt(x ^ 2 + y ^ 2) < 24 then
+					surface.set_tiles({{name = "stone-path", position = {x, y}}}, true)
+				end
+			end
+		end
 	end,
 }
 
@@ -268,13 +278,13 @@ Public.dense_atmosphere = {
 		local entity = event.created_entity
 		if not entity.valid then return end
 		if entity.surface.index ~= 1 then return end
-		if entity.name == "roboport" then entity.die() end
+		if entity.type == "roboport" then entity.die() end
 	end,
 	on_built_entity = function(event)
 		local entity = event.created_entity
 		if not entity.valid then return end
 		if entity.surface.index ~= 1 then return end
-		if entity.name == "roboport" then entity.die() end
+		if entity.type == "roboport" then entity.die() end
 	end,
 }
 


### PR DESCRIPTION
Print more messages to discord.
Resource modifiers only apply to richness.
Generate a tiny amount of power from solar in the eternal night and pitch black.
Always reward 1000 white science flasks.
Disabled the auto-launch via permissions.
Capsule drop radius further reduced.
Terrain segmentation a bit more random.
Fuel progress bar, +25 to +50 fuel requirement per world.
Add mixed ore to all worlds.
Add mixed ore modifier.
Satellites as a reroll token, mothership dispatches the satellite and rerolls the selectors.
Reroll is triggered at the top part of ship.