### PR TITLE
update

### DIFF
--- a/maps/journey/constants.lua
+++ b/maps/journey/constants.lua
@@ -57,6 +57,20 @@ Public.mothership_messages = {
 		"Please return to me.",
 		"Board me, so we can continue this adventure!",
 	},
+	answers = {
+		"Yes, great idea.",
+		"Yes, wonderful.",
+		"Yes, definitely.",
+		"Yes, i love it!",
+		"The calculations say yes.",
+		"I don't know how to feel about this.",
+		"Ask again later, my processors are very busy.",
+		"No, this is certainly wrong.",
+		"No, i don't think so.",
+		"No, you are wrong.",
+		"No, that would be weird.",
+		"The calculations say no.",
+	},
 }
 
 Public.mothership_gen_settings = {
@@ -159,26 +173,28 @@ Public.build_type_whitelist = {
 
 Public.unique_world_traits = {	
 	["lush"] = {"Lush", "Pure Vanilla."},	
-	["eternal_night"] = {"Eternal Night", "This world seems to be missing a sun."},
-	["dense_atmosphere"] = {"Dense Atmosphere", "Your roboport structures seem to malfunction."},
+	["abandoned_library"] = {"Abandoned Library", "No blueprints to be found."},
+	["lazy_bastard"] = {"Lazy Bastard", "The machine does the job."},		
+	["oceanic"] = {"Oceanic", "Arrrr, the flame turrets seem to malfunction in this climate."},
+	["ribbon"] = {"Ribbon", "Go right. (or left)"},
+	["wasteland"] = {"Wasteland", "Rusty treasures."},
+	["infested"] = {"Infested", "They lurk inside."},
 	["pitch_black"] = {"Pitch Black", "No light may reach this realm."},
 	["volcanic"] = {"Volcanic", "The floor is (almost) lava."},
-	["matter_anomaly"] = {"Matter Anomaly", "Why can't i hold all these ores."},
+	["matter_anomaly"] = {"Matter Anomaly", "Why can't i hold all these ores.\nThe laser turret structures seem to malfunction."},
 	["mountainous"] = {"Mountainous", "Diggy diggy hole!"},
-	["quantum_anomaly"] = {"Quantum Anomaly", "Research complete."},	
-	["replicant_fauna"] = {"Replicant Fauna", "The biters feed on your structures."},
-	["tarball"] = {"Tarball", "Door stuck, Door stuck..."},
+	["eternal_night"] = {"Eternal Night", "This world seems to be missing a sun."},
+	["dense_atmosphere"] = {"Dense Atmosphere", "Your roboport structures seem to malfunction."},
+	["undead_plague"] = {"Undead Plague", "The dead are restless."},
 	["swamps"] = {"Swamps", "No deep water to be found in this world."},	
-	["chaotic_resources"] = {"Chaotic Resources", "Something to sort out."},
-	["infested"] = {"Infested", "They lurk inside."},
+	["chaotic_resources"] = {"Chaotic Resources", "Something to sort out."},	
 	["low_mass"] = {"Low Mass", "You feel light footed and the robots are buzzing."},	
 	["eternal_day"] = {"Eternal Day", "The sun never moves."},	
-	["undead_plague"] = {"Undead Plague", "The dead are restless."},
+	["quantum_anomaly"] = {"Quantum Anomaly", "Research complete."},
+	["replicant_fauna"] = {"Replicant Fauna", "The biters feed on your structures."},
+	["tarball"] = {"Tarball", "Door stuck, Door stuck..."},
 	--[[
 	]]
-	
-	--["wasteland"] = {"Wasteland", "Smells like sulfur."},
-	--["wetlands"] = {"Wetlands", "Many rivers and many fish."},
 }
 
 return Public

--- a/maps/journey/main.lua
+++ b/maps/journey/main.lua
@@ -34,6 +34,24 @@ local function on_chunk_generated(event)
 	Functions.on_mothership_chunk_generated(event)
 end
 
+local function on_console_chat(event)
+    if not event.player_index then return end
+    local player = game.players[event.player_index]
+    local message = event.message
+    message = string.lower(message)
+	local a, b = string.find(message, "?", 1, true)
+    if not a then return end
+	local a, b = string.find(message, "mother", 1, true)
+    if not a then return end
+	local answer = Constants.mothership_messages.answers[math.random(1, #Constants.mothership_messages.answers)]
+	if math.random(1, 4) == 1 then
+		for _ = 1, math.random(2, 5), 1 do table.insert(journey.mothership_messages, "") end
+		table.insert(journey.mothership_messages, "...")
+	end
+	for _ = 1, math.random(15, 30), 1 do table.insert(journey.mothership_messages, "") end
+	table.insert(journey.mothership_messages, answer)
+end
+
 local function on_player_joined_game(event)
     local player = game.players[event.player_index]
 	Functions.draw_gui(journey)
@@ -72,29 +90,31 @@ end
 
 local function on_built_entity(event)
     Functions.deny_building(event)
+	Functions.register_built_silo(event, journey)
 	local unique_modifier = Unique_modifiers[journey.world_trait]
-	if unique_modifier.on_built_entity then unique_modifier.on_built_entity(event) end
+	if unique_modifier.on_built_entity then unique_modifier.on_built_entity(event, journey) end
 end
 
 local function on_robot_built_entity(event)
     Functions.deny_building(event)
+	Functions.register_built_silo(event, journey)
 	local unique_modifier = Unique_modifiers[journey.world_trait]
-	if unique_modifier.on_robot_built_entity then unique_modifier.on_robot_built_entity(event) end
+	if unique_modifier.on_robot_built_entity then unique_modifier.on_robot_built_entity(event, journey) end
 end
 
 local function on_player_mined_entity(event)
     local unique_modifier = Unique_modifiers[journey.world_trait]
-	if unique_modifier.on_player_mined_entity then unique_modifier.on_player_mined_entity(event) end
+	if unique_modifier.on_player_mined_entity then unique_modifier.on_player_mined_entity(event, journey) end
 end
 
 local function on_robot_mined_entity(event)
     local unique_modifier = Unique_modifiers[journey.world_trait]
-	if unique_modifier.on_robot_mined_entity then unique_modifier.on_robot_mined_entity(event) end
+	if unique_modifier.on_robot_mined_entity then unique_modifier.on_robot_mined_entity(event, journey) end
 end
 
 local function on_entity_died(event)
     local unique_modifier = Unique_modifiers[journey.world_trait]
-	if unique_modifier.on_entity_died then unique_modifier.on_entity_died(event) end
+	if unique_modifier.on_entity_died then unique_modifier.on_entity_died(event, journey) end
 end
 
 local function on_rocket_launched(event)
@@ -126,17 +146,18 @@ end
 local function on_init()
     local T = Map.Pop_info()
     T.main_caption = 'The Journey'
-    T.sub_caption = 'v 1.7'
+    T.sub_caption = 'v 1.8'
     T.text =
         table.concat(
         {	
-			'The selectors in the mothership, allow you to select a destination.\n',
-			'Once enough players are on a selector, mothership will start traveling.\n',
-			'A teleporter will be deployed, after reaching the target.\n',
-			'It is however, only capable of transfering the subjects body, anything besides will be left on the ground.\n\n',
+			'The selectors in the mothership, allow you to choose a destination.\n',
+			'Worlds can be rerolled by spending a satellite at the top selector.\n',
+			'Once enough players are on a selector, mothership will start traveling.\n\n',
 			
-			'Worlds will get more difficult with each jump, adding the chosen modifiers.\n',
-			'Worlds can be rerolled by spending a satellite.\n',
+			'A teleporter will be deployed, after reaching the target.\n',
+			'It is however, only capable of transfering the subjects body.\n\n',
+			
+			'Worlds will get more difficult with each jump, stacking the chosen modifiers.\n',		
             'Launch uranium fuel cells via rocket cargo, to advance to the next world.\n',
 			'The tooltips on the top buttons yield informations about the current world.\n',
 			'If the journey ends, an admin can fully reset the map via command "/reset-journey".\n\n',
@@ -199,3 +220,4 @@ Event.add(defines.events.on_built_entity, on_built_entity)
 Event.add(defines.events.on_robot_mined_entity, on_robot_mined_entity)
 Event.add(defines.events.on_player_mined_entity, on_player_mined_entity)
 Event.add(defines.events.on_entity_died, on_entity_died)
+Event.add(defines.events.on_console_chat, on_console_chat)


### PR DESCRIPTION
Faster capsule drops and shuffled.
Built silos always have auto-launch toggled off.
Rocket silos will attempt to auto-launch every 30 seconds.
Max satellites stored is now 1 + 1 every third world.
Mothership will now answer your questions.
Teleports now always lead to 0,0.
Chunk deletion made a bit slower.
50 % less research cost in quantum anomaly.
Only units are now affected in undead plague.
Replicant fauna nerf.
Ghosts, pipes, containers and walls are now minable in tarball.
Laser turrets are broken in matter anomaly.
Biters only spawn from rocks and trees in infested.
New World types ribbon, wasteland, oceanic, lazy bastard and abandoned library.