### PR TITLE
rpg magic fixes and improvement

### DIFF
--- a/modules/rpg/gui.lua
+++ b/modules/rpg/gui.lua
@@ -756,6 +756,7 @@ Gui.on_click(
                 player.play_sound({path = 'utility/cannot_build', volume_modifier = 0.75})
                 rpg_t.enable_entity_spawn = false
             end
+            Public.update_spell_gui_indicator(player)
         end
     end
 )

--- a/modules/rpg/main.lua
+++ b/modules/rpg/main.lua
@@ -1157,6 +1157,7 @@ local function on_player_used_capsule(event)
             if object.biter then
                 local e = surface.create_entity({name = obj_name, position = position, force = force})
                 tame_unit_effects(player, e)
+                rpg_t.mana = rpg_t.mana - object.mana_cost
             elseif object.aoe then
                 for x = 1, -1, -1 do
                     for y = 1, -1, -1 do
@@ -1174,9 +1175,9 @@ local function on_player_used_capsule(event)
             else
                 local e = surface.create_entity({name = obj_name, position = position, force = force})
                 e.direction = player.character.direction
+                rpg_t.mana = rpg_t.mana - object.mana_cost
             end
             p(({'rpg_main.object_spawned', obj_name}), Color.success)
-            rpg_t.mana = rpg_t.mana - object.mana_cost
         else
             p(({'rpg_main.out_of_reach'}), Color.fail)
             return

--- a/modules/rpg/settings.lua
+++ b/modules/rpg/settings.lua
@@ -85,7 +85,7 @@ function Public.update_spell_gui(player, spell_index)
     spell_table['mana-cost'].caption = spells[rpg_t.dropdown_select_index].mana_cost
     spell_table['mana'].caption = math.floor(rpg_t.mana)
     spell_table['maxmana'].caption = math.floor(rpg_t.mana_max)
-    
+
     Public.update_spell_gui_indicator(player)
 end
 
@@ -137,7 +137,7 @@ function Public.spell_gui_settings(player)
                 tooltip = names[rpg_t.dropdown_select_index3] or '---'
             }
         )
-        
+
         table.add({type = 'sprite-button', name = 'indicator', enabled = false})
         local b1 = table.add({type = 'sprite-button', name = 'mana-cost', tooltip = {'rpg_settings.mana_cost'}, caption = 0})
         local b2 = table.add({type = 'sprite-button', name = 'mana', tooltip = {'rpg_settings.mana'}, caption = 0})

--- a/modules/rpg/settings.lua
+++ b/modules/rpg/settings.lua
@@ -28,6 +28,16 @@ local function create_input_element(frame, type, value, items, index)
     return frame.add({type = 'text-box', text = value})
 end
 
+function Public.update_spell_gui_indicator(player)
+    local rpg_t = Public.get_value_from_player(player.index)
+    local main_frame = player.gui.screen[spell_gui_frame_name]
+    if not main_frame then
+        return
+    end
+    local indicator = main_frame['spell_table']['indicator']
+    indicator.sprite = 'virtual-signal/signal-' .. (rpg_t.enable_entity_spawn and 'green' or 'red')
+end
+
 function Public.update_spell_gui(player, spell_index)
     local rpg_t = Public.get_value_from_player(player.index)
     local spells, names = Public.rebuild_spells()
@@ -75,6 +85,8 @@ function Public.update_spell_gui(player, spell_index)
     spell_table['mana-cost'].caption = spells[rpg_t.dropdown_select_index].mana_cost
     spell_table['mana'].caption = math.floor(rpg_t.mana)
     spell_table['maxmana'].caption = math.floor(rpg_t.mana_max)
+    
+    Public.update_spell_gui_indicator(player)
 end
 
 function Public.spell_gui_settings(player)
@@ -125,7 +137,8 @@ function Public.spell_gui_settings(player)
                 tooltip = names[rpg_t.dropdown_select_index3] or '---'
             }
         )
-        table.add({type = 'flow'})
+        
+        table.add({type = 'sprite-button', name = 'indicator', enabled = false})
         local b1 = table.add({type = 'sprite-button', name = 'mana-cost', tooltip = {'rpg_settings.mana_cost'}, caption = 0})
         local b2 = table.add({type = 'sprite-button', name = 'mana', tooltip = {'rpg_settings.mana'}, caption = 0})
         local b3 = table.add({type = 'sprite-button', name = 'maxmana', tooltip = {'rpg_settings.mana_max'}, caption = 0})

--- a/modules/rpg/spells.lua
+++ b/modules/rpg/spells.lua
@@ -172,6 +172,7 @@ function Public.conjure_items()
         name = {'entity-name.medium-spitter'},
         obj_to_create = 'medium-spitter',
         level = 70,
+        biter = true,
         type = 'entity',
         mana_cost = 100,
         tick = 300,


### PR DESCRIPTION
When you cast aoe spells you spend mana for each tile + extra and after that your mana may become negative. (In screenshot summoned 1 chest, but used 300 mana)
![image](https://user-images.githubusercontent.com/20907711/125484430-7de9386f-a1f0-4396-b282-29565b3f2ea7.png)
Fixed lack of %name%'s pet over summoned medium spitter.
Added indicator which show is fish spells on. It's useful for players who like heals by fish.
![image](https://user-images.githubusercontent.com/20907711/125486108-567a6ad4-2d3f-47e6-8690-b8832112642f.png)
