### PR TITLE
Fix for wagons spawning out of reach

### DIFF
--- a/maps/mountain_fortress_v3/table.lua
+++ b/maps/mountain_fortress_v3/table.lua
@@ -18,7 +18,7 @@ Global.register(
 )
 
 Public.level_depth = 704
-Public.level_width = 524
+Public.level_width = 510
 
 Public.pickaxe_upgrades = {
     'Wood',


### PR DESCRIPTION
I believe the issue is that game generates the wagons while loading chunk of map on the edge and even before it loads the ground. Chunks are 32x32, and only 512 can be divided without remainder, so with 524 wagons can spawn in the chunk but not on ground. The thing is when changed to 512 it still sometimes spawns right on the edges (another issue with double tracks for unknown reason) which cannot be picked up. Making it 510 may not be perfect fix but after testing I haven't seen a wagon spawn out of reach.