### PR TITLE
Mining bonus and collapse speed up

### DIFF
--- a/maps/mountain_fortress_v3/table.lua
+++ b/maps/mountain_fortress_v3/table.lua
@@ -200,8 +200,12 @@ function Public.reset_table()
     this.sent_to_discord = false
     this.difficulty = {
         multiply = 0.25,
-        highest = 10
+        highest = 10,
+        lowest = 4
     }
+    this.player_balance = 20 -- game balance based on X players
+    this.mining_bonus = 0
+    this.mining_bonus_till_wave = 300
     this.market_announce = game.tick + 1200
     this.check_heavy_damage = true
     this.prestige_system_enabled = false


### PR DESCRIPTION
### All Submissions:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?


This is a major change to early game with less players, it basically involves the very upvoted saintknights idea from #suggestions: https://imgur.com/a/tx8MTWF

The mining speed bonus is same as in the table, which may seem high but I made alot of changes to make it reasonable (hopefuly). The bonus only lasts till mining_bonus_till_wave, currently set to 300. The bigger changes are to collapse speed, which is really slow with low players (e.g. 7.5 hours per zone with 1-3 players).

I made a spreadsheet that has 2 tabs, one for collapse speed, other for mining bonus. Anyone with the link should be able to view it, but I think you would have to make a copy to change the values. This PR sets it to what I believe is best.
https://docs.google.com/spreadsheets/d/1_ZIU5Qp7ovh8jESxdxTD6V01p6fcyt3i8tg-_wmSa2U/edit?usp=sharing

I've tested this thoroughly ingame while changing player_value, different collapse speeds, waves etc.
