### PR TITLE
Mtn v3 - fix spawning wrong turrets

### DIFF
--- a/maps/mountain_fortress_v3/entities.lua
+++ b/maps/mountain_fortress_v3/entities.lua
@@ -427,6 +427,9 @@ local function angry_tree(entity, cause, player)
                     force = 'enemy'
                 }
             )
+            if e.can_insert(data) then
+                e.insert(data)
+            end
             local callback = Token.get(cbl)
             callback(e, data)
             return

--- a/maps/mountain_fortress_v3/entities.lua
+++ b/maps/mountain_fortress_v3/entities.lua
@@ -422,7 +422,7 @@ local function angry_tree(entity, cause, player)
             local e =
                 entity.surface.create_entity(
                 {
-                    name = 'laser-turret',
+                    name = 'gun-turret',
                     position = entity.position,
                     force = 'enemy'
                 }


### PR DESCRIPTION
As I and Agocelt spoke through discord, having on_nth_tick refillment for laser-turret is UPS heavy and is not desync safe* since arbitrary numbers (consumption of the laser-turrets)

Changing this single line will spawn gun-turrets which will be refilled once their ammo depletes.