### PR TITLE
Balance changes

### DIFF
--- a/maps/mountain_fortress_v3/generate.lua
+++ b/maps/mountain_fortress_v3/generate.lua
@@ -13,6 +13,7 @@ local Public = {}
 local random = math.random
 local abs = math.abs
 local ceil = math.ceil
+local round = math.round
 local queue_task = Task.queue_task
 local tiles_per_call = 8
 local total_calls = ceil(1024 / tiles_per_call)
@@ -347,9 +348,13 @@ local function do_place_entities(data)
             if surface.can_place_entity(e) then
                 entity = surface.create_entity(e)
                 if entity then
-                    if e.note then
+                    if e.note then -- flamethrower-turret and artillery-turret are at default health, only gun-turret is modified
                         local modified_unit_health = WD.get('modified_unit_health')
-                        BiterHealthBooster.add_unit(entity, modified_unit_health.current_value + 1)
+                        local final_health = round(modified_unit_health.current_value * 0.5, 3)
+                        if final_health < 1 then
+                            final_health = 1
+                        end
+                        BiterHealthBooster.add_unit(entity, final_health)
                     end
                     wintery(entity)
                     if e.direction then
@@ -380,9 +385,14 @@ local function do_place_entities(data)
         else
             entity = surface.create_entity(e)
             if entity then
-                if e.note then
+                if e.note then -- small-worm-turret, medium-worm-turret, big-worm-turret, behemoth-worm-turret
                     local modified_unit_health = WD.get('modified_unit_health')
-                    BiterHealthBooster.add_unit(entity, modified_unit_health.current_value + 1)
+                    local worm_unit_settings = WD.get('worm_unit_settings')
+                    local final_health = round(modified_unit_health.current_value * worm_unit_settings.scale_units_by_health[entity.name], 3)
+                    if final_health < 1 then
+                        final_health = 1
+                    end
+                    BiterHealthBooster.add_unit(entity, final_health)
                 end
                 wintery(entity)
                 if e.direction then

--- a/modules/wave_defense/main.lua
+++ b/modules/wave_defense/main.lua
@@ -502,6 +502,9 @@ local function spawn_biter(surface, position, forceSpawn, is_boss_biter, unit_se
     if increase_health_per_wave and not is_boss_biter then
         local modified_unit_health = Public.get('modified_unit_health')
         local final_health = round(modified_unit_health.current_value * unit_settings.scale_units_by_health[biter.name], 3)
+        if final_health < 1 then
+            final_health = 1
+        end
         debug_print_health('final_health - unit: ' .. biter.name .. ' with h-m: ' .. final_health)
         BiterHealthBooster.add_unit(biter, final_health)
     end

--- a/modules/wave_defense/table.lua
+++ b/modules/wave_defense/table.lua
@@ -101,6 +101,14 @@ function Public.reset_wave_defense()
             ['behemoth-spitter'] = 0.25
         }
     }
+    this.worm_unit_settings = { -- note that final health modifier isn't lower than 1
+        scale_units_by_health = {
+            ['small-worm-turret'] = 0.8,
+            ['medium-worm-turret'] = 0.6,
+            ['big-worm-turret'] = 0.4,
+            ['behemoth-worm-turret'] = 0.2,
+        }
+    }
 end
 
 --- This gets values from our table

--- a/modules/wave_defense/table.lua
+++ b/modules/wave_defense/table.lua
@@ -92,13 +92,13 @@ function Public.reset_wave_defense()
     this.unit_settings = {
         scale_units_by_health = {
             ['small-biter'] = 1,
-            ['medium-biter'] = 1,
-            ['big-biter'] = 0.3,
-            ['behemoth-biter'] = 0.15,
+            ['medium-biter'] = 0.75,
+            ['big-biter'] = 0.5,
+            ['behemoth-biter'] = 0.25,
             ['small-spitter'] = 1,
-            ['medium-spitter'] = 1,
-            ['big-spitter'] = 0.3,
-            ['behemoth-spitter'] = 0.15
+            ['medium-spitter'] = 0.75,
+            ['big-spitter'] = 0.5,
+            ['behemoth-spitter'] = 0.25
         }
     }
 end

--- a/modules/wave_defense/threat_events.lua
+++ b/modules/wave_defense/threat_events.lua
@@ -2,6 +2,7 @@ local Public = require 'modules.wave_defense.table'
 local Event = require 'utils.event'
 local BiterHealthBooster = require 'modules.biter_health_booster_v2'
 local math_random = math.random
+local round = math.round
 local Token = require 'utils.token'
 local Task = require 'utils.task'
 
@@ -200,13 +201,18 @@ function Public.build_worm()
         return
     end
     local u = unit.surface.create_entity({name = worm, position = position, force = unit.force})
+    local worm_unit_settings = Public.get('worm_unit_settings')
     local modified_unit_health = Public.get('modified_unit_health')
     local modified_boss_unit_health = Public.get('modified_boss_unit_health')
 
     if boss then
         BiterHealthBooster.add_boss_unit(u, modified_boss_unit_health.current_value)
     else
-        BiterHealthBooster.add_unit(u, modified_unit_health.current_value)
+        local final_health = round(modified_unit_health.current_value * worm_unit_settings.scale_units_by_health[worm.name], 3)
+        if final_health < 1 then
+            final_health = 1
+        end
+        BiterHealthBooster.add_unit(u, final_health)
     end
 
     unit.surface.create_entity({name = 'blood-explosion-huge', position = position})


### PR DESCRIPTION
### All Submissions:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

This balances health of biters, worms and turrets, making early game easier and lategame harder. Based on experience from current games, lots of calculations and testing.
Table for Biter and turret health: https://i.imgur.com/JE3nNir.png
Table for Worm health: https://i.imgur.com/jp0YcON.png

Note that artillery and flamethrower turrets don't count in health modifier, so they're staying at default, perhaps for the better?