### PR TITLE
Turret filler module

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -79,6 +79,7 @@ require 'comfy_panel.config'
 --require 'modules.crawl_into_pipes'
 --require 'modules.no_acid_puddles'
 --require 'modules.simple_tags'
+--require 'modules.turret_filler'
 ---------------------------------------------------------------
 
 ---------------- ENABLE MAPS HERE ----------------

--- a/locale/en/modules.cfg
+++ b/locale/en/modules.cfg
@@ -14,6 +14,13 @@ soft_reset_reshape=>> The world has been reshaped, welcome to __1__ number __2__
 soft_reset_welcome_mapkeeper=[color=blue]Mapkeeper:[/color] Welcome to __1__!
 soft_reset_reshape_mapkeeper=[color=blue]Mapkeeper:[/color] The world has been reshaped, welcome to __1__ number __2__!
 
+turret_filler=Turret Filler
+turret_filler_tooltip=Automatically fill turrets with ammo when placed
+turret_filler_label_enabled=Enabled:
+turret_filler_label_amount=Amount:
+turret_filler_ammo_type=Select Ammo:
+turret_filler_ammo_lower=Enable lower tiers?
+
 [modules_towny]
 map_info=__1__\n\n__2__\n\n__3__\n\n__4__\n\n__5__
 map_info1=To ally or settle with another town, drop a fish on their market or character. (Default Hotkey Z)\nThey will have to do the same to you to complete the request.\nCoal yields the opposite result, as it will make foes or banish settlers.

--- a/maps/chronosphere/gui.lua
+++ b/maps/chronosphere/gui.lua
@@ -319,7 +319,7 @@ local function world_gui(player)
     frame.add({type = 'line'})
 
     local close = frame.add({type = 'button', name = 'close_world', caption = 'Close'})
-    close.style.horizontal_align = 'center'
+    close.style.horizontally_stretchable = true
     update_world_gui(player)
 end
 

--- a/maps/chronosphere/main.lua
+++ b/maps/chronosphere/main.lua
@@ -3,6 +3,7 @@
 require 'modules.biter_noms_you'
 require 'modules.biters_yield_coins'
 require 'modules.no_deconstruction_of_neutral_entities'
+require 'modules.turret_filler'
 local Server = require 'utils.server'
 local Comfylatron = require 'maps.chronosphere.comfylatron'
 local Ai = require 'maps.chronosphere.ai'

--- a/maps/chronosphere/ores.lua
+++ b/maps/chronosphere/ores.lua
@@ -155,6 +155,8 @@ function Public.prospect_ores(entity, surface, pos)
         end
         if world.id == 1 and (world.variant.id == 10 or world.variant.id == 11) then
             chance = chance + 30
+        elseif world.id == 5 then
+            chance = chance - 15
         end
         if math_random(chance + math_floor(20 * world.ores.factor), 100 + chance) >= 100 then
             spawn_ore_vein(surface, pos, world, extrasize)

--- a/modules/turret_filler.lua
+++ b/modules/turret_filler.lua
@@ -1,0 +1,236 @@
+local Event = require 'utils.event'
+local Global = require 'utils.global'
+
+local turrettable = {
+    players = {},
+    enabled = true
+}
+local Public = {}
+
+Global.register(
+    turrettable,
+    function(tbl)
+        turrettable = tbl
+    end
+)
+
+function Public.get_table()
+    return turrettable
+end
+
+local function draw_turret_button()
+    for _, player in pairs(game.connected_players) do
+        if not player.gui.top.turret_filler_button then
+            local b = player.gui.top.add({type = 'sprite-button', name = 'turret_filler_button', sprite = 'entity/gun-turret', tooltip = {'modules.turret_filler_tooltip'}})
+            b.style.minimal_height = 38
+            b.style.maximal_height = 38
+        end
+        player.gui.top.turret_filler_button.visible = turrettable.enabled
+    end
+end
+
+local function turret_gui(player)
+    if player.gui.screen['turret_filler'] then
+        player.gui.screen['turret_filler'].destroy()
+        return
+    end
+    if turrettable.enabled == false then
+        player.gui.top.turret_filler_button.visible = false
+        return
+    end
+    local playerdata = turrettable.players[player.index]
+    local frame = player.gui.screen.add({type = 'frame', name = 'turret_filler', caption = {'modules.turret_filler'}, direction = 'vertical'})
+    frame.location = {x = 150, y = 45}
+    frame.style.minimal_height = 200
+    frame.style.maximal_height = 500
+    frame.style.minimal_width = 200
+    frame.style.maximal_width = 400
+    frame.add({type = 'label', caption = {'modules.turret_filler_tooltip'}})
+    local switch_state = 'left'
+    if playerdata.enabled then
+        switch_state = 'right'
+    end
+    local t = frame.add({type = 'table', column_count = 4, name = 'turret_filler_enabled_table'})
+    t.add({type = 'label', caption = {'modules.turret_filler_label_enabled'}})
+    local label = t.add({type = 'label', caption = 'OFF'})
+    label.style.padding = 0
+    label.style.left_padding = 10
+    label.style.font_color = {0.77, 0.77, 0.77}
+    local switch = t.add({type = 'switch', name = 'turret_filler_enabled'})
+    switch.switch_state = switch_state
+    switch.style.padding = 0
+    switch.style.margin = 0
+    local label2 = t.add({type = 'label', caption = 'ON'})
+    label2.style.padding = 0
+    label2.style.font_color = {0.70, 0.70, 0.70}
+
+    local amount = playerdata.amount
+    local t2 = frame.add({type = 'table', column_count = 3, name = 'turret_filler_amount_table'})
+    t2.add({type = 'label', caption = {'modules.turret_filler_label_amount'}})
+    t2.add({type = 'slider', name = 'turret_filler_amount', minimum_value = 1, maximum_value = 100, value = amount or 5})
+    local textfield = t2.add({type = 'textfield', name = 'turret_filler_amount2', numeric = true, text = amount or 5})
+    textfield.style.width = 40
+    local t3 = frame.add({type = 'table', column_count = 4, name = 'turret_filler_ammo_table'})
+    t3.add({type = 'label', caption = {'modules.turret_filler_ammo_type'}})
+    local filter = {{filter = 'name', name = {'firearm-magazine', 'piercing-rounds-magazine', 'uranium-rounds-magazine'}}}
+    t3.add({type = 'choose-elem-button', name = 'turret_filler_ammo', elem_type = 'item', item = playerdata.ammo_type or 'firearm-magazine', elem_filters = filter})
+    t3.add({type = 'label', caption = {'modules.turret_filler_ammo_lower'}})
+    t3.add({type = 'checkbox', name = 'turret_filler_lower', state = playerdata.lower_allowed})
+    frame.add({type = 'line'})
+    local close = frame.add({type = 'button', name = 'close_turret_filler', caption = 'Save & Close'})
+    close.style.horizontally_stretchable = true
+end
+
+local function save_and_close(player)
+    local frame = player.gui.screen['turret_filler']
+    if not frame or not frame.valid then
+        return
+    end
+    turrettable.players[player.index].enabled = frame['turret_filler_enabled_table']['turret_filler_enabled'].switch_state == 'right'
+    turrettable.players[player.index].amount = frame['turret_filler_amount_table']['turret_filler_amount'].slider_value
+    turrettable.players[player.index].ammo_type = frame['turret_filler_ammo_table']['turret_filler_ammo'].elem_value
+    turrettable.players[player.index].lower_allowed = frame['turret_filler_ammo_table']['turret_filler_lower'].state
+    frame.destroy()
+end
+
+local function on_player_joined_game(event)
+    draw_turret_button()
+    if not turrettable.players[event.player_index] then
+        turrettable.players[event.player_index] = {
+            enabled = true,
+            amount = 5,
+            ammo_type = 'firearm-magazine',
+            lower_allowed = false
+        }
+    end
+end
+
+local function on_gui_click(event)
+    if not event then
+        return
+    end
+    if not event.element then
+        return
+    end
+    if not event.element.valid then
+        return
+    end
+    local player = game.get_player(event.player_index)
+    if event.element.name == 'turret_filler_button' then
+        turret_gui(player)
+        return
+    elseif event.element.name == 'close_turret_filler' then
+        save_and_close(player)
+        return
+    end
+end
+
+local function flying_text(surface, position, text, color)
+    surface.create_entity(
+        {
+            name = 'flying-text',
+            position = {position.x, position.y - 0.5},
+            text = text,
+            color = color
+        }
+    )
+end
+
+local function on_gui_value_changed(event)
+    local slider = event.element
+    if not slider or not slider.valid then
+        return
+    end
+    if slider.name ~= 'turret_filler_amount' then
+        return
+    end
+    local frame = slider.parent
+    frame['turret_filler_amount2'].text = tostring(slider.slider_value)
+end
+
+local function on_gui_text_changed(event)
+    local field = event.element
+    if not field or not field.valid then
+        return
+    end
+    if field.name ~= 'turret_filler_amount2' then
+        return
+    end
+    local frame = field.parent
+    local slider = frame['turret_filler_amount']
+    local number = tonumber(field.text) or 1
+    if number <= slider.get_slider_maximum() and number >= slider.get_slider_minimum() then
+        slider.slider_value = number
+    end
+end
+
+local function transfer_ammo(player, turret)
+    if not turrettable.players[player.index].enabled then
+        return
+    end
+    local item = turrettable.players[player.index].ammo_type
+    local count = player.get_item_count(item) or 0
+    if count == 0 and turrettable.players[player.index].lower_allowed then
+        if item == 'uranium-rounds-magazine' then
+            item = 'piercing-rounds-magazine'
+            count = player.get_item_count(item) or 0
+        end
+        if count == 0 and item == 'piercing-rounds-magazine' then
+            item = 'firearm-magazine'
+            count = player.get_item_count(item) or 0
+        end
+    end
+    if count > 0 then
+        local inserted = turret.insert({name = item, count = math.min(count, turrettable.players[player.index].amount)})
+        player.remove_item({name = item, count = inserted})
+        local text = '-' .. inserted .. ' [item=' .. item .. ']'
+        flying_text(turret.surface, turret.position, text, {r = 0.8, g = 0.2, b = 0.2})
+    end
+end
+
+local function on_built_entity(event)
+    if not turrettable.enabled then
+        return
+    end
+    local turret = event.created_entity
+    if not turret or not turret.valid then
+        return
+    end
+    if turret.name ~= 'gun-turret' then
+        return
+    end
+    local player = game.get_player(event.player_index)
+    if not player or not player.valid then
+        return
+    end
+    transfer_ammo(player, turret)
+end
+
+local function on_robot_built_entity(event)
+    if not turrettable.enabled then
+        return
+    end
+    local turret = event.created_entity
+    if not turret or not turret.valid then
+        return
+    end
+    if turret.name ~= 'gun-turret' then
+        return
+    end
+    local player = turret.last_user
+    if player and player.valid and player.connected then
+        local x, y = player.position.x - turret.position.x, player.position.y - turret.position.y
+        if player.surface == turret.surface and math.sqrt(x * x + y * y) <= 40 then
+            transfer_ammo(player, turret)
+        end
+    end
+end
+
+Event.add(defines.events.on_player_joined_game, on_player_joined_game)
+Event.add(defines.events.on_gui_click, on_gui_click)
+Event.add(defines.events.on_built_entity, on_built_entity)
+Event.add(defines.events.on_robot_built_entity, on_robot_built_entity)
+Event.add(defines.events.on_gui_value_changed, on_gui_value_changed)
+Event.add(defines.events.on_gui_text_changed, on_gui_text_changed)
+
+return Public


### PR DESCRIPTION
Automatically fills turret with ammo from player's inventory
Robot-built actions supported, as long as player who ordered the build is nearby
Supports to fill with lower tiers than selected ammo type, or just selected ammo type.

### All Submissions:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
