### PR TITLE
Fix serious error

### DIFF
--- a/utils/antigrief.lua
+++ b/utils/antigrief.lua
@@ -86,8 +86,11 @@ local function increment(t, v)
     t[#t + 1] = (v or 1)
 end
 
+-- Removes the first 100 entries of a table
 local function overflow(t)
-    table.remove(t, 1)
+    for _=1,100,1 do
+        table.remove(t, 1) 
+    end
 end
 
 local function get_entities(item_name, entities)
@@ -443,6 +446,15 @@ local function on_entity_died(event)
                 return
             end
         end
+        
+        if not this.friendly_fire_history then
+            this.friendly_fire_history = {}
+        end
+
+        if #this.friendly_fire_history > this.limit then
+            overflow(this.friendly_fire_history)
+        end
+        
         local t = abs(floor((game.tick) / 60))
         t = FancyTime.short_fancy_time(t)
         local str = '[' .. t .. '] '

--- a/utils/antigrief.lua
+++ b/utils/antigrief.lua
@@ -89,7 +89,7 @@ end
 -- Removes the first 100 entries of a table
 local function overflow(t)
     for _=1,100,1 do
-        table.remove(t, 1) 
+        table.remove(t, 1)
     end
 end
 
@@ -446,7 +446,6 @@ local function on_entity_died(event)
                 return
             end
         end
-        
         if not this.friendly_fire_history then
             this.friendly_fire_history = {}
         end
@@ -454,7 +453,6 @@ local function on_entity_died(event)
         if #this.friendly_fire_history > this.limit then
             overflow(this.friendly_fire_history)
         end
-        
         local t = abs(floor((game.tick) / 60))
         t = FancyTime.short_fancy_time(t)
         local str = '[' .. t .. '] '


### PR DESCRIPTION
### All Submissions:

- [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [X] Have you lint your code (lua lint) locally prior to submission?

### Changes to Core Features:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully ran tests with your changes locally?  (Does not add new logic that would require factorio testing)

### Comments

Error was in --Friendly Fire History -> local function on_entity_died(event)

There is a unique case, when an item dies and is not within blacklisted_types (belts and so on), but is within the whitelist_types array (I would guess this is for trees?), the friendy_fire history is incremented, but not checked for a limit.

Previously, this was a none-issue, as the list would be cleared when any other case is trigger. Now, however, only 1 log entry is deleted when it overflows, and only without that case. So every time somebody triggers that special case, by lets say destroying a tree, the array is increased by one without removing the first entry.

This should hopefully fix that.