### PR TITLE
Expanse and fixes

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -16,7 +16,8 @@ map_info_text=This is a harsh world, the heat is unbearable and the sand is shar
 [expanse]
 map_info_main_caption=-- E x p a n s e --
 map_info_sub_caption=
-map_info_text=The blue chests are hungry.\nFeed them and they will reward you with more land.\n\nThe friendly infini tree will provide you with all the wood you ever wanted.\nThe everlasting rock with be happy to provide resources for you.\n\nIf you find yourself stuck, put a reroll token, the small plane toy, in the chest to get a new offer.\nUnlocking chests may drop additional tokens.
+map_info_text=The blue chests are hungry.\nFeed them and they will reward you with more land.\n\nThe friendly infini tree will provide you with all the wood you ever wanted.\nThe everlasting rock with be happy to provide resources for you.\n\nIf you find yourself stuck, put a reroll token, the COIN, in the chest to get a new offer.\nUnlocking chests may drop additional tokens.\nBiters might invade your lands, we managed to mark the danger sites, but biters might choose some of them randomly.\nMining research now increases inventory size.
+biters_invasion_warning=Warning! Biters are aproaching your positions and will attack in about __1__ seconds! We detected __2__ groups aproaching some of the marked positions!
 
 [fish_defender]
 map_info_main_caption=--Fish Defender--

--- a/modules/backpack_research.lua
+++ b/modules/backpack_research.lua
@@ -3,7 +3,10 @@
 local Event = require 'utils.event'
 
 local function on_research_finished(event)
-    event.research.force.character_inventory_slots_bonus = game.forces.player.mining_drill_productivity_bonus * 100
+    local force = event.research.force
+    local toolbelt_bonus = (force.technologies['toolbelt'].researched and 10) or 0
+    local prod_bonus = force.mining_drill_productivity_bonus * 100
+    force.character_inventory_slots_bonus = prod_bonus + toolbelt_bonus
 end
 
 Event.add(defines.events.on_research_finished, on_research_finished)


### PR DESCRIPTION
### All Submissions:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [x] Have you lint your code (lua lint) locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### Comments
- fix for satellite score button being 2px bigger than all other buttons on top panel
- fix for satellite score progress bar being scuffed, now it properly fills whole thing vertically
- fix for backpack module not taking into account toolbelt research
- Expanse fixes so it is operable
- Expanse: moved starting objects few tiles away from each other so there is okay space around each
- Expanse: reroll token is now COIN, that makes it not really compatible with any module introducing easy access to coins
- Expanse: Added tracking and gui window to show statistics of items used for opening tiles
- Expanse: Added biter invasion feature, each opened tile has chance to be marked for invasion, when enough tiles are marked (based on evolution, visible in the stats panel), some are rolled for an attack in 2 minutes. It probably still needs a bit more of juice to make it more engaging.
- Expanse: Added render icons above chests, showing the items requested for easier navigation what is needed.