### PR TITLE
Mf small edits

### DIFF
--- a/locale/en/mtn_fortress_v3.cfg
+++ b/locale/en/mtn_fortress_v3.cfg
@@ -83,8 +83,10 @@ discharge_unlocked=Discharge defense has now been unlocked at the market!
 artillery_unlocked=Artillery has now been unlocked at the market!
 wd_paused=__1__ unlocked the last missing piece for the mystical chest!\n[color=yellow]Wave Defense has been paused for 5 minutes![/color]
 wd_resumed=[color=yellow]Wave Defense has been resumed![/color]
-mining_bonus=__1__ unlocked the last missing piece for the mystical chest!\n[color=yellow]Mining bonus has been applied for 15 minutes![/color]
+mining_bonus=__1__ unlocked the last missing piece for the mystical chest!\n[color=yellow]Mining speed bonus has been applied for 15 minutes![/color]
+mining_bonus_end=Mining speed bonus has ended!
 movement_bonus=__1__ unlocked the last missing piece for the mystical chest!\n[color=yellow]Movement speed bonus has been applied for 15 minutes![/color]
+movement_bonus_end=Movement speed bonus has ended!
 coin_bonus=__1__ unlocked the last missing piece for the mystical chest!\n[color=yellow]Coins has been distributed![/color]
 xp_bonus=__1__ unlocked the last missing piece for the mystical chest!\n[color=yellow]XP has been granted to Global pool![/color]
 inventory_bonus=__1__ unlocked the last missing piece for the mystical chest!\n[color=yellow]Inventory slot upgrade has been applied![/color]

--- a/maps/mountain_fortress_v3/basic_markets.lua
+++ b/maps/mountain_fortress_v3/basic_markets.lua
@@ -52,7 +52,7 @@ market.caspules = {
     ['defender-capsule'] = {value = 18, rarity = 1},
     ['distractor-capsule'] = {value = 68, rarity = 5},
     ['destroyer-capsule'] = {value = 74, rarity = 7},
-    ['discharge-defense-remote'] = {value = 900, rarity = 8},
+    ['discharge-defense-remote'] = {value = 8222, rarity = 8},
     ['artillery-targeting-remote'] = {value = 1024, rarity = 7},
     ['raw-fish'] = {value = 6, rarity = 1}
 }

--- a/maps/mountain_fortress_v3/basic_markets.lua
+++ b/maps/mountain_fortress_v3/basic_markets.lua
@@ -52,7 +52,7 @@ market.caspules = {
     ['defender-capsule'] = {value = 18, rarity = 1},
     ['distractor-capsule'] = {value = 68, rarity = 5},
     ['destroyer-capsule'] = {value = 74, rarity = 7},
-    ['discharge-defense-remote'] = {value = 8222, rarity = 8},
+    ['discharge-defense-remote'] = {value = 900, rarity = 8},
     ['artillery-targeting-remote'] = {value = 1024, rarity = 7},
     ['raw-fish'] = {value = 6, rarity = 1}
 }

--- a/maps/mountain_fortress_v3/mystical_chest.lua
+++ b/maps/mountain_fortress_v3/mystical_chest.lua
@@ -272,6 +272,8 @@ local restore_mining_speed_token =
         if mc_rewards.temp_boosts.mining then
             force.manual_mining_speed_modifier = force.manual_mining_speed_modifier - 0.5
             mc_rewards.temp_boosts.mining = nil
+            local message = ({'locomotive.mining_bonus_end'})
+            Alert.alert_all_players(10, message, nil, 'achievement/tech-maniac')
         end
     end
 )
@@ -284,6 +286,8 @@ local restore_movement_speed_token =
         if mc_rewards.temp_boosts.movement then
             force.character_running_speed_modifier = force.character_running_speed_modifier - 0.2
             mc_rewards.temp_boosts.movement = nil
+            local message = ({'locomotive.movement_bonus_end'})
+            Alert.alert_all_players(10, message, nil, 'achievement/tech-maniac')
         end
     end
 )


### PR DESCRIPTION
### All Submissions:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [x] Have you lint your code (lua lint) locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### Comments

Mystical chest mining and movement speed bonuses last 15mins, it'd be nice to know when they end. :) Also helps knowing when this reward is available again.

Discharge remote costs 1024 as a static price in locomotive market and the cost in random markets outside is currently absurd, so changed it to 900. It chooses between 75-125% which can be anywhere between 675-1125 coins. This is a small difference but may be worthy of purchase.

