### PR TITLE
Expanse update - locale, early uranium access, fixes

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -16,8 +16,17 @@ map_info_text=This is a harsh world, the heat is unbearable and the sand is shar
 [expanse]
 map_info_main_caption=-- E x p a n s e --
 map_info_sub_caption=
-map_info_text=The blue chests are hungry.\nFeed them and they will reward you with more land.\n\nThe friendly infini tree will provide you with all the wood you ever wanted.\nThe everlasting rock with be happy to provide resources for you.\n\nIf you find yourself stuck, put a reroll token, the COIN, in the chest to get a new offer.\nUnlocking chests may drop additional tokens.\nBiters might invade your lands, we managed to mark the danger sites, but biters might choose some of them randomly.\nMining research now increases inventory size.
+map_info_text=The blue chests are hungry.\nFeed them and they will reward you with more land.\n\nThe friendly infini tree will provide you with all the wood you ever wanted.\nThe everlasting rock with be happy to provide resources for you.\n\nIf you find yourself stuck, put a reroll token, the COIN, in the chest to get a new offer.\nUnlocking chests may drop additional tokens.\nBiters might invade your lands, we managed to mark the danger sites, but biters might choose some of them randomly.\nMining research now increases inventory size.\nTank with acid allows some uranium from the rock, if you have uranium research.
 biters_invasion_warning=Warning! Biters are aproaching your positions and will attack in about __1__ seconds! We detected __2__ groups aproaching some of the marked positions!
+tokens_dropped=__1__ has dropped their tokens! __2__
+chest_reset=The hungry chest has renewed its offers! __1__
+colored_text=[color=__1__,__2__,__3__]__4__[/color]
+gps=[gps=__1__,__2__,__3__]
+tile_unlock=__1__ has unlocked new grounds! __2__
+stats_gui=Expanse hungry chest stats
+stats_size=Total size unlocked: __1__
+stats_attack=Next biter invasion: __1__ / __2__ possible positions, __3__ groups
+stats_item_tooltip=__1__, value: __2__
 
 [fish_defender]
 map_info_main_caption=--Fish Defender--

--- a/maps/expanse/functions.lua
+++ b/maps/expanse/functions.lua
@@ -371,7 +371,7 @@ local function init_container(expanse, entity, budget)
     local item_stacks = {}
     local roll_count = 3
     for _ = 1, roll_count, 1 do
-        for _, stack in pairs(Price_raffle.roll(math.floor(cell_value / roll_count), 3, nil, cell_value / (roll_count * 3))) do
+        for _, stack in pairs(Price_raffle.roll(math.floor(cell_value / roll_count), 3, nil, cell_value / (roll_count * 6))) do
             if not item_stacks[stack.name] then
                 item_stacks[stack.name] = stack.count
             else

--- a/maps/expanse/functions.lua
+++ b/maps/expanse/functions.lua
@@ -180,6 +180,25 @@ local function remove_old_renders(container)
     end
 end
 
+function Public.spawn_units(spawner)
+    local evolution = game.forces.enemy.evolution_factor
+    local position = spawner.position
+    for i = 1, 4 + math.floor(8 * evolution), 1 do
+        local biter_roll = BiterRaffle.roll('mixed', evolution)
+        local free_pos = spawner.surface.find_non_colliding_position(biter_roll, {x = position.x + math.random(-8,8), y = position.y + math.random(-8,8)}, 12, 0.05)
+        spawner.surface.create_entity({name = biter_roll, position = free_pos or position, force = 'enemy'})
+    end
+end
+
+function Public.get_item_tooltip(name)
+    return {'expanse.stats_item_tooltip', game.item_prototypes[name].localised_name, Price_raffle.get_item_worth(name)}
+end
+
+function Public.invasion_numbers()
+    local evo = game.forces.enemy.evolution_factor
+    return {candidates = 3 + math.floor(evo * 10), groups =  1 + math.floor(evo * 4)}
+end
+
 function Public.invasion_warn(event)
     local seconds = (120 * 60 - event.delay) / 60
     game.print({'expanse.biters_invasion_warning', seconds, event.size}, {r = 0.88, g = 0.22, b = 0.22})
@@ -211,7 +230,7 @@ function Public.invasion_trigger(event)
     local biters = {}
     for i = 1, 5 + math.floor(30 * evolution) + round * 5, 1 do
         local biter_roll = BiterRaffle.roll('mixed', evolution)
-        local free_pos = surface.find_non_colliding_position(biter_roll, position, 12, 0.05)
+        local free_pos = surface.find_non_colliding_position(biter_roll, {x = position.x + math.random(-8,8), y = position.y + math.random(-8,8)}, 12, 0.05)
         biters[#biters + 1] = surface.create_entity({name = biter_roll, position = free_pos or position, force = 'enemy'})
     end
     local group = surface.create_unit_group{position = position, force = 'enemy'}
@@ -222,7 +241,7 @@ function Public.invasion_trigger(event)
     group.start_moving()
     local worm_roll = BiterRaffle.roll('worm', evolution)
     for i = 1, 3 + math.floor(7 * evolution), 1 do
-        local worm_pos = surface.find_non_colliding_position(worm_roll, {x = position.x + math.random(-6,6), y = position.y + math.random(-6,6)}, 12, 0.1)
+        local worm_pos = surface.find_non_colliding_position(worm_roll, {x = position.x + math.random(-12,12), y = position.y + math.random(-12,12)}, 12, 0.1)
         if worm_pos then
             surface.create_entity({name = worm_roll, position = worm_pos, force = 'enemy'})
         end
@@ -247,15 +266,14 @@ local function schedule_biters(expanse, surface, position, delay, round)
     table.insert(expanse.schedule, {tick = game.tick + delay + 120 * 60, event = 'invasion_trigger', parameters = {surface = surface, position = position, round = round}})
 end
 
-local function plan_invasion(expanse, evolution)
+local function plan_invasion(expanse, invasion_numbers)
     local candidates = expanse.invasion_candidates
     table.shuffle_table(candidates)
-    local size = 1 + math.floor(evolution * 4)
-    schedule_warning(expanse, size, 0)
-    schedule_warning(expanse, size, 60 * 60)
-    schedule_warning(expanse, size, 90 * 60)
-    local rounds = 4 + math.random(1, 4)
-    for i = 1, size, 1 do
+    schedule_warning(expanse, invasion_numbers.groups, 0)
+    schedule_warning(expanse, invasion_numbers.groups, 60 * 60)
+    schedule_warning(expanse, invasion_numbers.groups, 90 * 60)
+    local rounds = 4 + math.random(1, 8)
+    for i = 1, invasion_numbers.groups, 1 do
         local surface = candidates[i].surface
         local position = candidates[i].position
         schedule_detonation(expanse, surface, position)
@@ -264,16 +282,16 @@ local function plan_invasion(expanse, evolution)
         end
         rendering.set_time_to_live(candidates[i].render, 122 * 60 + rounds * 300)
     end
-    for j = size + 1, #candidates, 1 do
+    for j = invasion_numbers.groups + 1, #candidates, 1 do
         rendering.set_time_to_live(candidates[j].render, 122 * 60)
     end
     expanse.invasion_candidates = {}
 end
 
 function Public.check_invasion(expanse)
-    local evolution = game.forces.enemy.evolution_factor
-    if #expanse.invasion_candidates >= 3 + math.floor(evolution * 10) then
-        plan_invasion(expanse, evolution)
+    local invasion_numbers = Public.invasion_numbers()
+    if #expanse.invasion_candidates >= invasion_numbers.candidates then
+        plan_invasion(expanse, invasion_numbers)
     end
 end
 
@@ -305,10 +323,6 @@ function Public.expand(expanse, left_top)
         }
     )
 
-    for _, e in pairs(source_surface.find_entities(area)) do
-        e.destroy()
-    end
-
     local positions = {
         {x = left_top.x + math.random(1, square_size - 2), y = left_top.y},
         {x = left_top.x, y = left_top.y + math.random(1, square_size - 2)},
@@ -328,13 +342,12 @@ function Public.expand(expanse, left_top)
         local a = math.floor(expanse.square_size * 0.5)
         for x = 1, 3, 1 do
             for y = 1, 3, 1 do
-                surface.set_tiles({{name = 'water', position = {a + x + 2, a + y - 2}}}, true)
+                surface.set_tiles({{name = 'water', position = {a + x + 2, a + y + 2}}}, true)
             end
         end
-        surface.create_entity({name = 'crude-oil', position = {a - 5, a}, amount = 1500000})
-
-        Task.set_timeout_in_ticks(30, delay_infini_tree_token, {surface = surface, position = {a, a - 3}})
-        surface.create_entity({name = 'rock-big', position = {a, a}})
+        surface.create_entity({name = 'crude-oil', position = {a - 4, a - 4}, amount = 1500000})
+        Task.set_timeout_in_ticks(30, delay_infini_tree_token, {surface = surface, position = {a - 4, a + 4}})
+        surface.create_entity({name = 'rock-big', position = {a + 4, a - 4}})
         surface.spill_item_stack({a, a + 2}, {name = 'coin', count = 1}, false, nil, false)
         surface.spill_item_stack({a + 0.5, a + 2.5}, {name = 'coin', count = 1}, false, nil, false)
         surface.spill_item_stack({a - 0.5, a + 2.5}, {name = 'coin', count = 1}, false, nil, false)
@@ -349,18 +362,16 @@ function Public.expand(expanse, left_top)
     end
 end
 
-local function init_container(expanse, entity)
+local function init_container(expanse, entity, budget)
     local left_top = get_left_top(expanse, entity.position)
     if not left_top then
         return
     end
-
-    local cell_value = get_cell_value(expanse, left_top)
-
+    local cell_value = budget or get_cell_value(expanse, left_top)
     local item_stacks = {}
-    local roll_count = 2
+    local roll_count = 3
     for _ = 1, roll_count, 1 do
-        for _, stack in pairs(Price_raffle.roll(math.floor(cell_value / roll_count), 2)) do
+        for _, stack in pairs(Price_raffle.roll(math.floor(cell_value / roll_count), 3, nil, cell_value / (roll_count * 3))) do
             if not item_stacks[stack.name] then
                 item_stacks[stack.name] = stack.count
             else
@@ -370,7 +381,7 @@ local function init_container(expanse, entity)
     end
 
     local price = {}
-    local offset = -2
+    local offset = -3
     for k, v in pairs(item_stacks) do
         table.insert(price, {name = k, count = v, render = create_costs_render(entity, k, offset)})
         offset = offset + 1
@@ -378,6 +389,14 @@ local function init_container(expanse, entity)
 
     local containers = expanse.containers
     containers[entity.unit_number] = {entity = entity, left_top = left_top, price = price}
+end
+
+local function get_remaining_budget(container)
+    local budget = 0
+    for _, item_stack in pairs(container.price) do
+        budget = budget + (item_stack.count * Price_raffle.get_item_worth(item_stack.name))
+    end
+    return budget
 end
 
 function Public.set_container(expanse, entity)
@@ -404,10 +423,14 @@ function Public.set_container(expanse, entity)
                 expanse.cost_stats['coin'] = (expanse.cost_stats['coin'] or 0) + count_removed
                 script.raise_event(expanse.events.gui_update, {item = 'coin'})
                 remove_old_renders(container)
-                init_container(expanse, entity)
+                init_container(expanse, entity, get_remaining_budget(container))
                 container = expanse.containers[entity.unit_number]
-                game.print("The hungry chest has renewed it's offer! [gps=" .. math.floor(entity.position.x) .. ',' .. math.floor(entity.position.y) .. ',expanse]')
+                game.print({'expanse.chest_reset', {'expanse.gps', math.floor(entity.position.x), math.floor(entity.position.y), 'expanse'}})
             end
+        end
+        if contents['infinity-chest'] then
+            remove_old_renders(container)
+            container.price = {}
         end
     end
 

--- a/maps/expanse/main.lua
+++ b/maps/expanse/main.lua
@@ -2,7 +2,7 @@
 
 --CONFIGS
 local cell_size = 15 -- size of each territory to unlock
-local chance_to_receive_token = 0.35 -- chance of a hungry chest, dropping a token after unlocking, can be above 1 for multiple
+local chance_to_receive_token = 0.20 -- chance of a hungry chest, dropping a token after unlocking, can be above 1 for multiple
 
 require 'modules.satellite_score'
 require 'modules.backpack_research'
@@ -55,16 +55,18 @@ local function set_nauvis()
     local surface = game.surfaces[1]
     local map_gen_settings = surface.map_gen_settings
     map_gen_settings.autoplace_controls = {
-        ['coal'] = {frequency = 10, size = 0.7, richness = 0.5},
-        ['stone'] = {frequency = 10, size = 0.7, richness = 0.5},
-        ['copper-ore'] = {frequency = 10, size = 0.7, richness = 0.75},
-        ['iron-ore'] = {frequency = 10, size = 0.7, richness = 1},
+        ['coal'] = {frequency = 6, size = 0.7, richness = 0.5},
+        ['stone'] = {frequency = 6, size = 0.4, richness = 0.5},
+        ['copper-ore'] = {frequency = 6, size = 0.7, richness = 0.95},
+        ['iron-ore'] = {frequency = 6, size = 0.7, richness = 1},
         ['uranium-ore'] = {frequency = 10, size = 0.7, richness = 1},
         ['crude-oil'] = {frequency = 20, size = 1.5, richness = 1.5},
         ['trees'] = {frequency = 1.75, size = 1.25, richness = 1},
-        ['enemy-base'] = {frequency = 10, size = 2, richness = 1}
+        ['enemy-base'] = {frequency = 10, size = 10, richness = 2}
     }
-    map_gen_settings.starting_area = 0.25
+    map_gen_settings.water = 0.25
+    map_gen_settings.terrain_segmentation = 12
+    map_gen_settings.starting_area = 0.05
     surface.map_gen_settings = map_gen_settings
     for chunk in surface.get_chunks() do
         surface.delete_chunk({chunk.x, chunk.y})
@@ -78,6 +80,7 @@ local function reset()
     expanse.invasion_candidates = {}
     expanse.schedule = {}
     expanse.size = 1
+    expanse.acid_tank = nil
     Autostash.insert_into_furnace(true)
 
     local map_gen_settings = {
@@ -126,7 +129,7 @@ local function reset()
     end
 end
 
-local ores = {'copper-ore', 'iron-ore', 'stone', 'coal'}
+local ores = {'copper-ore', 'iron-ore', 'stone', 'coal', 'iron-ore', 'copper-ore', 'coal'}
 local function generate_ore(surface, left_top)
     local seed = game.surfaces[1].map_gen_settings.seed
     local left_top_x = left_top.x
@@ -138,11 +141,23 @@ local function generate_ore(surface, left_top)
             local pos = {x = left_top_x + x, y = left_top_y + y}
             if surface.can_place_entity({name = 'iron-ore', position = pos}) then
                 local noise = GetNoise('smol_areas', pos, seed)
-                if math.abs(noise) > 0.78 then
-                    local amount = 500 + math.sqrt(pos.x ^ 2 + pos.y ^ 2) * 2
-                    local i = math.floor(noise * 40 + math.abs(pos.x) * 0.05) % 4 + 1
+                if math.abs(noise) > 0.78 or math.abs(noise) < 0.11 then
+                    local amount = 500 + math.sqrt(pos.x ^ 2 + pos.y ^ 2) * 4
+                    local i = math.floor(noise * 40 + math.abs(pos.x) * 0.05) % 7 + 1
                     surface.create_entity({name = ores[i], position = pos, amount = amount})
                 end
+            end
+        end
+    end
+end
+
+local function on_resource_depleted(event)
+    local ore = event.entity
+    if ore and ore.valid then
+        local distance = math.sqrt(ore.position.x ^ 2 + ore.position.y ^ 2)
+        if ore.name == 'stone' and distance > 150 then
+            if math.random(1, 4) == 1 then
+                ore.surface.create_entity({name = 'uranium-ore', position = ore.position, amount = 20 + math.floor(distance / 2)})
             end
         end
     end
@@ -155,10 +170,13 @@ local function on_chunk_generated(event)
         if expanse.override_nauvis then
             if surface.index == 1 then
                 for _, e in pairs(surface.find_entities_filtered({area = event.area, name = {'iron-ore', 'copper-ore', 'coal', 'stone', 'uranium-ore'}})) do
-                    surface.create_entity({name = e.name, position = e.position, amount = 500 + math.sqrt(e.position.x ^ 2 + e.position.y ^ 2) * 2})
+                    surface.create_entity({name = e.name, position = e.position, amount = 500 + math.sqrt(e.position.x ^ 2 + e.position.y ^ 2) * 3})
                     e.destroy()
                 end
                 generate_ore(surface, event.area.left_top)
+                for _, unit in pairs(surface.find_entities_filtered({area = event.area, type = {'unit', 'turret', 'unit-spawner', 'fish'}, force = {'enemy', 'neutral'}})) do
+                    unit.active = false
+                end
             end
         end
         return
@@ -187,6 +205,20 @@ local function on_chunk_generated(event)
     surface.set_tiles(tiles, true)
 end
 
+local function on_area_cloned(event)
+    local source_surface = event.source_surface
+    local dest_surface = event.destination_surface
+    for _, cloned_entity in pairs(dest_surface.find_entities(event.destination_area)) do
+        cloned_entity.active = true
+        if cloned_entity.type == 'unit-spawner' then
+            Functions.spawn_units(cloned_entity)
+        end
+    end
+    for _, source_entity in pairs(source_surface.find_entities(event.source_area)) do
+        source_entity.destroy()
+    end
+end
+
 local function container_opened(event)
     local entity = event.entity
     if not entity then
@@ -204,9 +236,8 @@ local function container_opened(event)
     local expansion_position = Functions.set_container(expanse, entity)
     if expansion_position then
         local player = game.players[event.player_index]
-        local colored_player_name =
-            table.concat({'[color=', player.color.r * 0.6 + 0.35, ',', player.color.g * 0.6 + 0.35, ',', player.color.b * 0.6 + 0.35, ']', player.name, '[/color]'})
-        game.print(colored_player_name .. ' unlocked new grounds! [gps=' .. math.floor(expansion_position.x) .. ',' .. math.floor(expansion_position.y) .. ',expanse]')
+        local colored_player_name = {'expanse.colored_text', player.color.r * 0.6 + 0.35, player.color.g * 0.6 + 0.35, player.color.b * 0.6 + 0.35, player.name}
+        game.print({'expanse.tile_unlock', colored_player_name, {'expanse.gps', math.floor(expansion_position.x), math.floor(expansion_position.y), 'expanse'}})
         expanse.size = (expanse.size or 1) + 1
         if math.random(1, 4) == 1 then
             if player.surface.count_tiles_filtered({position = expansion_position, radius = 6, collision_mask = 'water-tile'}) > 40 then
@@ -233,16 +264,43 @@ local function on_gui_closed(event)
     container_opened(event)
 end
 
+local function assign_acid_tank(entity)
+    local tanks = entity.surface.find_entities_filtered{name = 'storage-tank', position = entity.position, radius = 8}
+    for _, tank in pairs(tanks) do
+        if tank.get_fluid_count('sulfuric-acid') > 0 then
+            return tank
+        end
+    end
+    return nil
+end
+
+local function uranium_mining(entity)
+    if not game.forces.player.technologies['uranium-processing'].researched then return end
+    if not expanse.acid_tank or not expanse.acid_tank.valid then
+        expanse.acid_tank = assign_acid_tank(entity)
+    end
+    local tank = expanse.acid_tank
+    if tank and tank.valid then
+        local acid = tank.get_fluid_count('sulfuric-acid')
+        if acid > 5 then
+            tank.remove_fluid{name = 'sulfuric-acid', amount = 4}
+            entity.surface.spill_item_stack(entity.position, {name = 'uranium-ore', count = 2}, true, nil, true)
+            entity.surface.create_entity{name = 'flying-text', position = tank.position, text = '-4 [fluid=sulfuric-acid]', color = {r = 0.88, g = 0.02, b = 0.02}}
+        end
+    end
+end
+
 local inf_ores = {'iron-ore', 'iron-ore', 'copper-ore', 'coal'}
 local function infini_rock(entity)
     if entity.type ~= 'simple-entity' then
         return
     end
     local a = math.floor(expanse.square_size * 0.5)
-    if entity.position.x == a and entity.position.y == a then
-        entity.surface.create_entity({name = 'rock-big', position = {a, a}})
+    if entity.position.x == a + 4 and entity.position.y == a - 4 then
+        entity.surface.create_entity({name = 'rock-big', position = {a + 4, a - 4}})
         entity.surface.spill_item_stack(entity.position, {name = inf_ores[math.random(1, 4)], count = math.random(80, 160)}, true, nil, true)
-        entity.surface.spill_item_stack(entity.position, {name = 'stone', count = math.random(15, 30)}, true, nil, true)
+        entity.surface.spill_item_stack(entity.position, {name = 'stone', count = math.random(5, 15)}, true, nil, true)
+        uranium_mining(entity)
     end
 end
 
@@ -251,8 +309,8 @@ local function infini_tree(entity)
         return
     end
     local a = math.floor(expanse.square_size * 0.5)
-    if entity.position.x == a and entity.position.y == a - 3 then
-        entity.surface.create_entity({name = 'tree-0' .. math.random(1, 9), position = {a, a - 3}})
+    if entity.position.x == a - 4 and entity.position.y == a + 4 then
+        entity.surface.create_entity({name = 'tree-0' .. math.random(1, 9), position = {a - 4, a + 4}})
     end
 end
 
@@ -291,7 +349,7 @@ local function on_pre_player_left_game(event)
         for _ = 1, removed_count, 1 do
             player.surface.spill_item_stack(player.position, {name = 'coin', count = 1}, false, nil, false)
         end
-        game.print(player.name .. ' dropped their tokens! [gps=' .. math.floor(player.position.x) .. ',' .. math.floor(player.position.y) .. ',' .. player.surface.name .. ']')
+        game.print({'expanse.tokens_dropped', player.name, {'expanse.gps', math.floor(player.position.x), math.floor(player.position.y), player.surface.name}})
     end
 end
 
@@ -348,19 +406,19 @@ local function on_tick()
 end
 
 local function resource_stats(parent, name, count)
-    local button = parent.add({type = 'sprite-button', name = name .. '_sprite', sprite = 'item/' .. name, enabled = false})
+    local button = parent.add({type = 'sprite-button', name = name .. '_sprite', sprite = 'item/' .. name, enabled = false, tooltip = Functions.get_item_tooltip(name)})
     local label = parent.add({type = 'label', name = name .. '_label', caption = format_number(tonumber(count), true), tooltip = count})
     label.style.width = 40
     return button, label
 end
 
 local function create_main_frame(player)
-    local frame = player.gui.screen.add({type = 'frame', name = main_frame_name, caption = 'Expanse hungry chest stats', direction = 'vertical'})
+    local frame = player.gui.screen.add({type = 'frame', name = main_frame_name, caption = {'expanse.stats_gui'}, direction = 'vertical'})
     frame.location = {x = 10, y = 40}
     frame.style.maximal_height = 600
-    local evo = game.forces.enemy.evolution_factor
-    frame.add({type = 'label', name = 'size', caption = 'Total size unlocked: ' .. expanse.size or 1})
-    frame.add({type = 'label', name = 'biters', caption = 'Biter attack: ' .. 3 + math.floor(7 * evo) .. ' positions, ' .. 1 + math.floor(evo * 4) .. ' armies'})
+    local invasion_numbers = Functions.invasion_numbers()
+    frame.add({type = 'label', name = 'size', caption = {'expanse.stats_size', expanse.size or 1}})
+    frame.add({type = 'label', name = 'biters', caption = {'expanse.stats_attack', #expanse.invasion_candidates, invasion_numbers.candidates, invasion_numbers.groups}})
     local scroll = frame.add({type = 'scroll-pane', name = 'scroll_pane', horizontal_scroll_policy = 'never', vertical_scroll_policy = 'auto-and-reserve-space'})
     local frame_table = scroll.add({type = 'table', name = 'resource_stats', column_count = 8})
     for name, count in Random.spairs(expanse.cost_stats, function(t,a,b) return t[a] > t[b] end) do
@@ -372,9 +430,9 @@ local function update_resource_gui(event)
     for _, player in pairs(game.connected_players) do
         if player.gui.screen[main_frame_name] then
             local frame = player.gui.screen[main_frame_name]
-            local evo = game.forces.enemy.evolution_factor
-            frame['size'].caption = 'Total size unlocked: ' .. expanse.size or 1
-            frame['biters'].caption = 'Biter attack: ' .. 3 + math.floor(evo * 10) .. ' positions, ' .. 1 + math.floor(evo * 4) .. ' armies'
+            local invasion_numbers = Functions.invasion_numbers()
+            frame['size'].caption = {'expanse.stats_size', expanse.size or 1}
+            frame['biters'].caption = {'expanse.stats_attack', #expanse.invasion_candidates, invasion_numbers.candidates, invasion_numbers.groups}
             local frame_table = frame['scroll_pane']['resource_stats']
             local count = expanse.cost_stats[event.item] or 0
             if not frame_table[event.item .. '_label'] then
@@ -407,6 +465,8 @@ end
 Event.on_init(on_init)
 Event.on_nth_tick(60, on_tick)
 Event.add(defines.events.on_chunk_generated, on_chunk_generated)
+Event.add(defines.events.on_area_cloned, on_area_cloned)
+Event.add(defines.events.on_resource_depleted, on_resource_depleted)
 Event.add(defines.events.on_entity_died, infini_resource)
 Event.add(defines.events.on_gui_closed, on_gui_closed)
 Event.add(defines.events.on_gui_opened, on_gui_opened)


### PR DESCRIPTION
- localized the scenario (ready for translations)
- uranium can be sourced in tiny amounts from central rock if you have storage tank with acid nearby (prevents lockout)
- spaced out initial area even more
- mixed ore now spawns also in continuous veins to incentivize targetted expansion and to automate mining more
- toned down ratio of stone from rock and stone patches
- added landfill as valid chest request, this should help with too much stone too
- with way more mixed ore, the natural ore patches got toned down a bit
- copper richness more close to iron now (boosted a bit)
- depleted stone veins have chance to spawn tiny bit of uranium at distance > 150 (nearest pure uranium nodes can be still found at 450+ distance, can't do much with that except just spawning it directly)
- fixed the statistics window showing wrong invasion info
- statistics window now tracks also active dangers so you can see for example "3 / 5"  
- statistics window now has tooltip on each item with item name and its value
- chests now choose 3 items in 3 rounds instead of 2x 2, this should make the unlock costs a bit more varietal
- using coin now rolls new items based on previously remaining value of chest, instead of resetting to initial value (so filling items you could still gives you advantage)
- value blacklist initial try, chest can't roll item that would alone take more than 1/18 of total value (dunno if it really does what it should do - reduce chance of high tier items in early areas, maybe will need more tweaking, currently it won't pick item that doesn't fit at least twice into the local budget share for that roll)
- coin drop chance reduced to 20% as the early stages should be easier to unlock
- deactivated all entities on source map to prevent UPS usage
- on expansion, entities are activated, and spawners now pre-spawn few units based on evolution
- invasions can now do up to 12 spawning rounds, and the spawning area might be wider than the cell (so defenses too closeby might be overwhelmed, but it should prevent biters getting too stuck)
- way more biters to find by opening tiles, so get your defenses ready
- for cheaters and testing purposes, putting infinity chest into request chests unlocks the area instantly (no way to get the item without cheats so hopefully okay to have it there)