### PR TITLE
Mf small fixes

### DIFF
--- a/maps/mountain_fortress_v3/terrain.lua
+++ b/maps/mountain_fortress_v3/terrain.lua
@@ -475,6 +475,7 @@ local function zone_14(x, y, data, _, adjusted_zones)
     local entities = data.entities
     local buildings = data.buildings
     local treasure = data.treasure
+    data.forest_zone = true
 
     local small_caves = get_perlin('small_caves', p, seed)
     local noise_cave_ponds = get_perlin('cave_ponds', p, seed)

--- a/modules/rpg/main.lua
+++ b/modules/rpg/main.lua
@@ -90,7 +90,7 @@ local function on_gui_click(event)
         elseif event.button == defines.mouse_button_type.right then
             local left = rpg_t.points_left / 2
             if left > 2 then
-                for _ = 1, left, 1 do
+                for _ = 2, left, 1 do -- for _ = 1 results in uneven distribution
                     if rpg_t.points_left <= 0 then
                         Public.toggle(player, true)
                         return


### PR DESCRIPTION
### All Submissions:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [x] Have you lint your code (lua lint) locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### Comments

Examples when currently distributing half points:
150 points left -> 76 points goes into skill, 74 points left
30 points left -> 16 points goes into skill, 14 points left
5 points left -> 3 points goes into skill, 2 points left
4 points left -> 1 point goes into skill, 3 points left

The fix results in this:
150 points left -> 75 points goes into skill, 75 points left
57 points left -> 28 points goes into skill, 29 points left -- Imo it's better when more points are left to distribute in case of odd numbers, as inserted points cannot be reverted
30 points left -> 15 points goes into skill, 15 points left
5 points left -> 2 points goes into skill, 3 points left
4 points left -> 1 point goes into skill, 3 points left -- doesn't really matter

Coin nerf applies to this zone:
![image](https://user-images.githubusercontent.com/78453369/196479830-5b2cd9fe-d0cb-4b9d-bb0c-c25146524ce3.png)