### PR TITLE
Pirates: Increase difficulty of hard and nightmare

### DIFF
--- a/maps/pirates/coredata.lua
+++ b/maps/pirates/coredata.lua
@@ -124,7 +124,7 @@ Public.difficulty_options = {
 
 	{value = 1.4, icon = 'item/uranium-rounds-magazine', text = {'pirates.difficutly_hard'}, associated_color = {r = 255, g = 50, b = 50}},
 
-	{value = 2, icon = 'item/atomic-bomb', text = {'pirates.difficulty_nightmare'}, associated_color = {r = 170, g = 60, b = 60}},
+	{value = 2.1, icon = 'item/atomic-bomb', text = {'pirates.difficulty_nightmare'}, associated_color = {r = 170, g = 60, b = 60}},
 }
 function Public.get_difficulty_option_from_value(difficulty_value)
 	-- given a difficulty value, key in to the closesy entry in the above table. (organising things this way allows us to make changes to the 'value' keys in the above table without disrupting e.g. past highscores data)

--- a/maps/pirates/coredata.lua
+++ b/maps/pirates/coredata.lua
@@ -122,9 +122,9 @@ Public.difficulty_options = {
 
 	{value = 0.9, icon = 'item/piercing-rounds-magazine', text = {'pirates.difficulty_normal'}, associated_color = {r = 255, g = 255, b = 50}},
 
-	{value = 1.3, icon = 'item/uranium-rounds-magazine', text = {'pirates.difficutly_hard'}, associated_color = {r = 255, g = 50, b = 50}},
+	{value = 1.4, icon = 'item/uranium-rounds-magazine', text = {'pirates.difficutly_hard'}, associated_color = {r = 255, g = 50, b = 50}},
 
-	{value = 1.8, icon = 'item/atomic-bomb', text = {'pirates.difficulty_nightmare'}, associated_color = {r = 170, g = 60, b = 60}},
+	{value = 2, icon = 'item/atomic-bomb', text = {'pirates.difficulty_nightmare'}, associated_color = {r = 170, g = 60, b = 60}},
 }
 function Public.get_difficulty_option_from_value(difficulty_value)
 	-- given a difficulty value, key in to the closesy entry in the above table. (organising things this way allows us to make changes to the 'value' keys in the above table without disrupting e.g. past highscores data)


### PR DESCRIPTION
### All Submissions:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [x] Have you lint your code (lua lint) locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### Comments

Difficulty=1.8 was defeated recently. This was skilled play, but it revealed the recent nerf to Nightmare went a little too far!

The difficulty of Hard and Nightmare is increased.