### PR TITLE
tile_history

### DIFF
--- a/utils/antigrief.lua
+++ b/utils/antigrief.lua
@@ -282,11 +282,11 @@ local function on_player_built_tile(event)
         return
     end
     local placed_tiles = event.tiles
-    
+
     local player = game.get_player(event.player_index)
 
     local surface = game.surfaces[event.surface_index]
-    
+
     if not surface then
         return
     end
@@ -296,10 +296,10 @@ local function on_player_built_tile(event)
     local is_landfill
     if event.tile.name == "landfill" then
         is_landfill = true
-    else    
+    else
         is_landfill = false
-    end    
-        
+    end
+
     if is_landfill then
         --landfill history--
 
@@ -321,7 +321,7 @@ local function on_player_built_tile(event)
             overflow(this.tile_history)
         end
     end
-    
+
     local t = abs(floor((game.tick) / 60))
     t = FancyTime.short_fancy_time(t)
     local str = '[' .. t .. '] '
@@ -333,7 +333,7 @@ local function on_player_built_tile(event)
     str = str .. 'on ' .. surface.name
     str = str .. ' '
     str = str .. 'surface:' .. surface.index
-    
+
     if is_landfill then
         increment(this.landfill_history, str)
     else
@@ -975,7 +975,7 @@ local function on_player_deconstructed_area(event)
         str = str .. ' '
         str = str .. 'on ' .. surface.name
         str = str .. ' surface:' .. surface.index
-        
+
         increment(this.deconstruct_history, str)
 
         if this.enable_jail_when_decon and not player.admin then

--- a/utils/gui/admin.lua
+++ b/utils/gui/admin.lua
@@ -246,6 +246,7 @@ local function draw_events(data)
         ['Mining History'] = antigrief.mining_history,
         ['Mining Override History'] = antigrief.whitelist_mining_history,
         ['Landfill History'] = antigrief.landfill_history,
+        ['Tile History'] = antigrief.tile_history,
         ['Corpse Looting History'] = antigrief.corpse_history,
         ['Cancel Crafting History'] = antigrief.cancel_crafting_history,
         ['Deconstruct History'] = antigrief.deconstruct_history
@@ -506,6 +507,9 @@ local function create_admin_panel(data)
     end
     if antigrief.landfill_history then
         table.insert(histories, 'Landfill History')
+    end
+    if antigrief.tile_history then
+        table.insert(histories, 'Tile History')
     end
     if antigrief.corpse_history then
         table.insert(histories, 'Corpse Looting History')


### PR DESCRIPTION
### All Submissions:

- [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully ran tests with your changes locally?

### Comments

1. Adding tile history to admin history to detect forbidden activity via brick or concrete.
2. Fixed landfill_history, which was not adding anything new if the first tile of a grid happened to no be water before.
3. Added surface.name to every record. Probably unnecessary, but there it is now :)