### PR TITLE
Fix: drain amounts smaller than 2M over-draw accumulators

### DIFF
--- a/modules/charging_station.lua
+++ b/modules/charging_station.lua
@@ -28,6 +28,7 @@ local function discharge_accumulators(surface, position, force, power_needs)
                 else
                     power_drained = power_drained + power_needs
                     accu.energy = accu.energy - power_needs
+                    break
                 end
             elseif power_needs <= 0 then
                 break


### PR DESCRIPTION
### All Submissions:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [x] Have you lint your code (lua lint) locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### Comments

explanation: I noticed some (what I perceive to be) buggy draw behavior.
`power_needs` never gets cleared so the draw loop repeats for all accumulators when `power_needs` < 2M.
given the call site, this extra drawn energy is not actually usable.

I have tested the changes locally, and power draw seems a bit more in-line with my expectations.

I also notice the current implementation will perform a `surface.find_entities_filtered` call for _every equipment item_.
there is an optimization opportunity here, we can first enumerate the total power necessary, then use the existing `discharge_accumulators` implementation to draw this power all in one pass. we would iterate the equipment grid twice as much, but only perform an entity scan a single time. I am not too familiar with factorio lua performance optimization, but I believe this is a desirable tradeoff. this change is not included, I can introduce it separately if you would like.