### PR TITLE
Do not feed a player who is trying to spellcast

### DIFF
--- a/modules/hunger.lua
+++ b/modules/hunger.lua
@@ -1,6 +1,7 @@
 -- hunger module by mewmew --
 local Public = {}
 local P = require 'utils.player_modifiers'
+local RPG = require 'modules.rpg.table'
 
 local starve_messages = {' ran out of foodstamps.', ' starved.', ' should not have skipped breakfast today.'}
 
@@ -175,6 +176,9 @@ local function on_player_used_capsule(event)
     if event.item.name == 'raw-fish' then
         local player = game.players[event.player_index]
         if player.character.health < player.character.prototype.max_health + player.character_health_bonus + player.force.character_health_bonus then
+            return
+        end
+        if RPG.get_value_from_player(player.index, 'enable_entity_spawn') then
             return
         end
         Public.hunger_update(player, player_hunger_fish_food_value)


### PR DESCRIPTION
### All Submissions:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [x] Have you lint your code (lua lint) locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### Comments

explanation: I enabled both `hunger` and `rpg` (v2) locally, and noticed that the "player used capsule" handlers" fire simultaneously. the effect is that trying to spellcast causes the player to bloat, with no recourse.

my attempt at a fix here is to detect whether a player has spellcasting active, and use this to prevent updating the hunger value. this works for me locally.

note that this introduces a dependency on `modules.rpg.table`; nothing in the require path will cause `rpg` to be enabled where it is not currently enabled. I understand this pattern is a bit precarious, though, so please let me know if there is a better way to accomplish this.