### PR TITLE
Journey 1.9.4

### DIFF
--- a/maps/journey/functions.lua
+++ b/maps/journey/functions.lua
@@ -443,6 +443,7 @@ function Public.import_journey(journey)
         return
     else
 		Server.try_get_data('scenario_settings', 'journey_data', journey.import)
+		Server.set_data('scenario_settings', 'journey_updating', false)
 	end
 end
 
@@ -1209,6 +1210,16 @@ function Public.notify_discord(journey)
 		return
 	end
 	local caption = 'World ' .. journey.world_number .. ' | ' .. Constants.unique_world_traits[journey.world_trait].name
+	local modifier_message = ''
+	for _, mod in pairs(journey.world_selectors[journey.selected_world].modifiers) do
+		local sign = ''
+		if mod.value > 0 then sign = '+' end
+		modifier_message = modifier_message .. sign .. mod.value .. '% ' .. mod.name .. '\n'
+	end
+	local capsules = ''
+	for _, cap in pairs(journey.world_selectors[journey.selected_world].bonus_goods) do
+		capsules = capsules .. cap[2] .. 'x ' .. cap[1] .. '\n'
+	end
 	local message = {
 		title = 'World advanced',
 		description = 'Arriving at target destination!',
@@ -1224,8 +1235,18 @@ function Public.notify_discord(journey)
 			inline = 'true'
 		},
 		field3 = {
-			text1 = 'Fuel cells in mothership cargo:',
-			text2 = journey.mothership_cargo['uranium-fuel-cell'],
+			text1 = 'Satellites in mothership cargo:',
+			text2 = journey.mothership_cargo['satellite'] .. ' / ' .. journey.mothership_cargo_space['satellite'],
+			inline = 'false'
+		},
+		field4 = {
+			text1 = 'Modifiers changed:',
+			text2 = modifier_message,
+			inline = 'false'
+		},
+		field5 = {
+			text1 = 'Capsules gained:',
+			text2 = capsules,
 			inline = 'false'
 		}
 	}

--- a/maps/journey/unique_modifiers.lua
+++ b/maps/journey/unique_modifiers.lua
@@ -565,7 +565,6 @@ Public.railworld = {
 
 local delivery_options = {
     'solar-panel',
-    'rocket-part',
     'beacon',
     'assembling-machine-3',
     'low-density-structure',


### PR DESCRIPTION
Changed the Discord Embed on world arrival:
- no longer shows fuel in mothership, as it is always fully spent
- shows satellites storage
- shows the modifiers picked
- shows capsules gained

Removed rocket parts from speedrun item list, as that isn't  vanilla-obtainable item

Fixed that on scheduled autorestart, it would keep importing the situation as it didn't switched the import flag off
