### PR TITLE
Add stylua.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .git/
 maps/biter_battles_v3/
 todo/
-.stylua.toml
+stylua.toml
 
 #==Mac ignores==
 # General

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ maps/biter_battles_v3/
 todo/
 .stylua.toml
 
-
 #==Mac ignores==
 # General
 .DS_Store


### PR DESCRIPTION
~This PR allows StyLua to be used with the ComfyFactorio repository, without StyLua auto-changing all single quotes to double quotes (as is against our convention.)~

Update: Actually, a stylua.toml was already included in .gitignore, and what this PR actually does is correct it.