### PR TITLE
desert oasis update

### DIFF
--- a/maps/desert_oasis.lua
+++ b/maps/desert_oasis.lua
@@ -1,8 +1,10 @@
---luacheck: ignore
-require 'modules.satellite_score'
+if not script.active_mods['space-age'] then
+    require 'modules.satellite_score'
+end
 require 'modules.thirst'
 
 local Map_info = require 'modules.map_info'
+local FT = require 'utils.functions.flying_texts'
 
 local get_noise = require 'utils.math.get_noise'
 local table_insert = table.insert
@@ -17,15 +19,7 @@ local sand_damage = oasis_start * 100 + 16
 
 local trees = { 'tree-01', 'tree-04', 'tree-06', 'tree-08-red', 'tree-08', 'tree-09' }
 
-local tile_to_item = {
-    ['stone-path'] = 'stone-brick',
-    ['hazard-concrete-left'] = 'hazard-concrete',
-    ['hazard-concrete-right'] = 'hazard-concrete',
-    ['refined-hazard-concrete-left'] = 'refined-hazard-concrete',
-    ['refined-hazard-concrete-right'] = 'refined-hazard-concrete'
-}
-
-local save_tiles = {
+local safe_tiles = {
     ['stone-path'] = true,
     ['concrete'] = true,
     ['hazard-concrete-left'] = true,
@@ -34,43 +28,91 @@ local save_tiles = {
     ['refined-hazard-concrete-left'] = true,
     ['refined-hazard-concrete-right'] = true,
     ['water'] = true,
+    ['water-shallow'] = true,
+    ['water-mud'] = true,
     ['grass-1'] = true,
     ['grass-2'] = true,
     ['grass-3'] = true,
-    ['water'] = true,
     ['deepwater'] = true
 }
 
-local function get_moisture(position)
+local function calculate_vulcanus(surface, position)
+    local temperatures = surface.calculate_tile_properties({'vulcanus_temperature'}, {position})
+    local temperature = temperatures and temperatures['vulcanus_temperature'][1]
+    -- 75 mini hot, 100 hot a lot
+    -- 50% moisture, 0% moisture
+    local moisture = math.round((-2) * temperature + 200, 1)
+    return moisture
+end
+
+local function calculate_nauvis(_surface, position)
     local moisture = get_noise('oasis', position, storage.desert_oasis_seed)
     moisture = moisture * 128
     moisture = math.round(moisture, 1)
     return moisture
 end
 
+local function calculate_fulgora(surface, position)
+    local elevations = surface.calculate_tile_properties({'fulgora_elevation'}, {position})
+    local elevation = elevations['fulgora_elevation'][1]
+    -- 0 ocean, 105 plateaus
+    -- 60% moisture, 45% moisture
+    local moisture = math.round((-1/7) * elevation + 60, 1)
+    return moisture
+end
+
+local function calculate_gleba(surface, position)
+    local elevations = surface.calculate_tile_properties({'gleba_elevation'}, {position})
+    local elevation = elevations['gleba_elevation'][1]
+    -- 0 water, 150 plateaus
+    -- 100%+ moisture, 80% moisture
+    local moisture = math.round((-2/15) * elevation + 100, 1)
+    return moisture
+end
+
+local function calculate_aquilo(surface, position)
+    local moisture = 45
+    return moisture
+end
+
+local function get_moisture(surface, position)
+    local planet_calcs = {
+        nauvis = calculate_nauvis,
+        gleba = calculate_gleba,
+        vulcanus = calculate_vulcanus,
+        aquilo = calculate_aquilo,
+        fulgora = calculate_fulgora
+    }
+    local planet = surface.planet and surface.planet.name or 'custom'
+    local moisture = 50
+    if planet_calcs[planet] then
+        moisture = planet_calcs[planet](surface, position)
+    end
+    return moisture
+end
+
 local function moisture_meter(player, moisture)
-    local moisture_meter = player.gui.top.moisture_meter
+    local moisture_meter_gui = player.gui.top.moisture_meter
 
-    if not moisture_meter then
-        moisture_meter = player.gui.top.add({ type = 'frame', name = 'moisture_meter' })
-        moisture_meter.style.padding = 3
+    if not moisture_meter_gui then
+        moisture_meter_gui = player.gui.top.add({ type = 'frame', name = 'moisture_meter' })
+        moisture_meter_gui.style.padding = 3
 
-        local label = moisture_meter.add({ type = 'label', caption = 'Moisture Meter:' })
+        local label = moisture_meter_gui.add({ type = 'label', caption = 'Moisture Meter:' })
         label.style.font = 'heading-2'
         label.style.font_color = { 0, 150, 0 }
-        local label = moisture_meter.add({ type = 'label', caption = 0 })
-        label.style.font = 'heading-2'
-        label.style.font_color = { 175, 175, 175 }
+        local number_label = moisture_meter_gui.add({ type = 'label', caption = 0 })
+        number_label.style.font = 'heading-2'
+        number_label.style.font_color = { 175, 175, 175 }
     end
 
-    moisture_meter.children[2].caption = moisture
+    moisture_meter_gui.children[2].caption = moisture
 end
 
 local function draw_oasis(surface, left_top, seed)
     local tiles = {}
-    local size_of_tiles = 0
     local entities = {}
-    local size_of_entities = 0
+    local decoratives = {}
     local left_top_x = left_top.x
     local left_top_y = left_top.y
 
@@ -80,32 +122,40 @@ local function draw_oasis(surface, left_top, seed)
             local noise = get_noise('oasis', position, seed)
             if noise >= oasis_start then
                 if noise > water_start or noise > oasis_start + 0.035 and get_noise('cave_ponds', position, seed) > 0.72 then
-                    size_of_tiles = size_of_tiles + 1
-
-                    if noise > 0.85 then
-                        tiles[size_of_tiles] = { name = 'deepwater', position = position }
+                    if noise > 0.87 then
+                        tiles[#tiles + 1] = { name = 'deepwater', position = position }
+                    elseif noise > 0.85 then
+                        tiles[#tiles + 1] = { name = 'water', position = position }
+                    elseif noise > 0.83 then
+                        tiles[#tiles + 1] = { name = 'water-mud', position = position }
                     else
-                        tiles[size_of_tiles] = { name = 'water', position = position }
+                        tiles[#tiles + 1] = { name = 'water-shallow', position = position }
+                        if math_random(1, 6) == 1 then
+                            decoratives[#decoratives + 1] = {name = 'green-bush-mini', position = position, amount = math_random(1, 6)}
+                        end
                     end
 
                     if math_random(1, 64) == 1 then
-                        size_of_entities = size_of_entities + 1
-                        entities[size_of_entities] = { name = 'fish', position = position }
+                        entities[#entities + 1] = { name = 'fish', position = position }
                     end
                 else
-                    size_of_tiles = size_of_tiles + 1
-                    tiles[size_of_tiles] = { name = 'grass-' .. math_floor(noise * 32) % 3 + 1, position = position }
+                    tiles[#tiles + 1] = { name = 'grass-' .. math_floor(noise * 32) % 3 + 1, position = position }
 
                     for _, cliff in pairs(surface.find_entities_filtered({ type = 'cliff', position = position })) do
                         cliff.destroy()
                     end
 
                     if math_random(1, 12) == 1 and surface.can_place_entity({ name = 'coal', position = position, amount = 1 }) then
-                        size_of_entities = size_of_entities + 1
                         if math_abs(get_noise('n3', position, seed)) > 0.50 then
-                            entities[size_of_entities] = { name = trees[math_floor(get_noise('n2', position, seed) * 9) % 6 + 1], position = position }
+                            entities[#entities + 1] = { name = trees[math_floor(get_noise('n2', position, seed) * 9) % 6 + 1], position = position }
                         end
                     end
+                end
+            elseif noise < -0.9 then
+                decoratives[#decoratives + 1] = {name = 'sand-decal', position = position, amount = 1}
+            else
+                if math_random(1, 6) == 1 then
+                    decoratives[#decoratives + 1] = {name = 'sand-dune-decal', position = position, amount = 1}
                 end
             end
         end
@@ -118,11 +168,24 @@ local function draw_oasis(surface, left_top, seed)
             surface.create_entity(entity)
         end
     end
+    surface.create_decoratives({decoratives = decoratives, check_collision = true})
+end
+
+local function create_crash_site(surface, position)
+    local p = surface.find_non_colliding_position('stone', position, 50, 0.5)
+    if not p then
+        return
+    end
+    local e = surface.create_entity({ name = 'crash-site-spaceship', position = p, force = 'player', create_build_effect_smoke = false })
+    if not e or not e.valid then return end
+    e.insert({ name = 'repair-pack', count = 2 })
+    e.insert({ name = 'water-barrel', count = 5 })
+    e.minable = false
 end
 
 local function on_chunk_generated(event)
     local surface = event.surface
-    if surface.name ~= 'desert_oasis' then
+    if surface.name ~= 'nauvis' then
         return
     end
     local seed = storage.desert_oasis_seed
@@ -131,13 +194,6 @@ local function on_chunk_generated(event)
     for _, entity in pairs(surface.find_entities_filtered({ area = event.area, type = 'resource' })) do
         if get_noise('oasis', entity.position, seed) <= oasis_start then
             entity.destroy()
-        else
-            if prototypes.item[entity.name] then
-                surface.create_entity(
-                    { name = entity.name, position = entity.position, amount = math_random(200, 300) + math.sqrt(entity.position.x ^ 2 + entity.position.y ^ 2) * 0.65 }
-                )
-                entity.destroy()
-            end
         end
     end
 
@@ -152,19 +208,13 @@ local function on_chunk_generated(event)
             entity.destroy()
         end
     end
-
-    local noise = get_noise('oasis', left_top, seed)
-    if noise > oasis_start - 0.35 then
-        draw_oasis(surface, left_top, seed)
-        return
+    draw_oasis(surface, left_top, seed)
+    if left_top.x == 64 and left_top.y == 64 then
+        create_crash_site(surface, {75, 75})
     end
 end
 
 local function on_init()
-    if game.surfaces['desert_oasis'] then
-        return
-    end
-
     local T = Map_info.Pop_info()
     T.localised_category = 'desert_oasis'
     T.main_caption_color = { r = 170, g = 170, b = 0 }
@@ -174,20 +224,154 @@ local function on_init()
         water = 0.0,
         property_expression_names = {
             temperature = 50,
-            moisture = 0
+            moisture = 0,
+            elevation = 'elevation_nauvis'
         },
-        starting_area = 1,
+        starting_area = 3,
         terrain_segmentation = 0.1,
-        cliff_settings = { cliff_elevation_interval = 8, cliff_elevation_0 = 8 },
+        cliff_settings = {
+            cliff_elevation_interval = 40,
+            cliff_elevation_0 = 0,
+            cliff_smoothing = 0,
+            name = 'cliff',
+            richness = 1,
+            control = 'nauvis_cliff'
+        },
+        default_enable_all_autoplace_controls = false,
         autoplace_controls = {
-            ['coal'] = { frequency = 23, size = 0.5, richness = 0.5 },
+            ['coal'] = { frequency = 23, size = 0.5, richness = 1.5 },
             ['stone'] = { frequency = 20, size = 0.5, richness = 0.5 },
-            ['copper-ore'] = { frequency = 25, size = 0.5, richness = 0.5 },
-            ['iron-ore'] = { frequency = 35, size = 0.5, richness = 0.5 },
-            ['uranium-ore'] = { frequency = 20, size = 0.5, richness = 0.5 },
-            ['crude-oil'] = { frequency = 50, size = 0.55, richness = 1 },
+            ['copper-ore'] = { frequency = 25, size = 0.5, richness = 1.5 },
+            ['iron-ore'] = { frequency = 35, size = 0.5, richness = 1.5 },
+            ['uranium-ore'] = { frequency = 20, size = 0.5, richness = 1.5 },
+            ['crude-oil'] = { frequency = 50, size = 0.55, richness = 2 },
             ['trees'] = { frequency = 0.75, size = 0.75, richness = 0.1 },
-            ['enemy-base'] = { frequency = 15, size = 1, richness = 1 }
+            ['enemy-base'] = { frequency = 15, size = 1, richness = 1 },
+            ['nauvis_cliff'] = {frequency = 5, size = 3, richness = 2},
+            ['rocks'] = {frequency = 3, size = 6, richness = 5}
+        },
+        autoplace_settings = {
+            decorative = {
+                treat_missing_as_default = false,
+                settings = {
+
+                    ['red-desert-bush'] = {
+                        frequency = 4,
+                        richness = 4,
+                        size = 4
+                    },
+                    ['white-desert-bush'] = {
+                        frequency = 4,
+                        richness = 4,
+                        size = 4
+                    },
+                    ['small-rock'] = {
+                        frequency = 4,
+                        richness = 4,
+                        size = 4
+                    },
+                    ['small-sand-rock'] = {
+                        frequency = 6,
+                        richness = 4,
+                        size = 4
+                    },
+                    ['medium-sand-rock'] = {
+                        frequency = 8,
+                        richness = 4,
+                        size = 4
+                    },
+                }
+            },
+            tile = {
+                treat_missing_as_default = false,
+                settings = {
+                    ["red-desert-1"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    ["red-desert-2"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    ["red-desert-3"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    ["sand-1"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    ["sand-2"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    ["sand-3"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                }
+            },
+            entity = {
+                settings = {
+                    coal = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    ["copper-ore"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    ["crude-oil"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    fish = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    ['big-sand-rock'] = {
+                        frequency = 5,
+                        size = 3,
+                        richness = 3
+                    },
+                    ['huge-sand-rock'] = {
+                        frequency = 5,
+                        size = 3,
+                        richness = 3
+                    },
+                    ["huge-rock"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    ["iron-ore"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    stone = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                    ["uranium-ore"] = {
+                        frequency = 1,
+                        richness = 1,
+                        size = 1
+                    },
+                },
+                treat_missing_as_default = true
+            }
         }
     }
 
@@ -203,16 +387,14 @@ local function on_init()
             break
         end
     end
+    map_gen_settings.seed = storage.desert_oasis_seed
+    local surface = game.surfaces.nauvis
+    surface.map_gen_settings = map_gen_settings
+    surface.clear(true)
 
-    game.create_surface('desert_oasis', map_gen_settings)
-
-    local surface = game.surfaces['desert_oasis']
-    surface.request_to_generate_chunks({ 0, 0 }, 5)
+    surface.request_to_generate_chunks({ 0, 0 }, 3)
     surface.force_generate_chunk_requests()
-
-    local force = game.forces.player
-    force.technologies['landfill'].enabled = false
-    force.technologies['cliff-explosives'].enabled = false
+    surface.set_property('solar-power', 200)
 end
 
 local type_whitelist = {
@@ -228,9 +410,18 @@ local type_whitelist = {
     ['logistic-robot'] = true,
     ['rail-chain-signal'] = true,
     ['rail-signal'] = true,
-    ['curved-rail'] = true,
+    ['curved-rail-a'] = true,
+    ['curved-rail-b'] = true,
     ['straight-rail'] = true,
-    ['train-stop'] = true
+    ['half-diagonal-rail'] = true,
+    ['elevated-straight-rail'] = true,
+    ['elevated-half-diagonal-rail'] = true,
+    ['elevated-curved-rail-a'] = true,
+    ['elevated-curved-rail-b'] = true,
+    ['rail-support'] = true,
+    ['rail-ramp'] = true,
+    ['train-stop'] = true,
+    ['crash-site-spaceship'] = true
 }
 
 local function deny_building(event)
@@ -238,31 +429,34 @@ local function deny_building(event)
     if not entity.valid then
         return
     end
+    if entity.surface.name ~= 'nauvis' then
+        return
+    end
 
     if type_whitelist[event.entity.type] then
         return
     end
 
-    if save_tiles[entity.surface.get_tile(entity.position).name] then
+    if safe_tiles[entity.surface.get_tile(entity.position).name] then
         return
     end
+    local item = entity.prototype.items_to_place_this and entity.prototype.items_to_place_this[1]
 
     if event.player_index then
-        game.players[event.player_index].insert({ name = entity.name, count = 1 })
+        local player = game.get_player(event.player_index)
+        if player and player.valid then
+            if item then
+                player.insert(item)
+            end
+            FT.flying_text(player, entity.surface , entity.position, 'Can not be built in the sands!', { r = 0.98, g = 0.66, b = 0.22 })
+        end
     else
         local inventory = event.robot.get_inventory(defines.inventory.robot_cargo)
-        inventory.insert({ name = entity.name, count = 1 })
+        if item then
+            inventory.insert(item)
+        end
+        FT.flying_text(nil, entity.surface , entity.position, 'Can not be built in the sands!', { r = 0.98, g = 0.66, b = 0.22 })
     end
-
-    event.entity.surface.create_entity(
-        {
-            name = 'flying-text',
-            position = entity.position,
-            text = 'Can not be built in the sands!',
-            color = { r = 0.98, g = 0.66, b = 0.22 }
-        }
-    )
-
     entity.destroy()
 end
 
@@ -275,17 +469,15 @@ local function on_robot_built_entity(event)
 end
 
 local function deny_tile_building(surface, inventory, tiles, tile)
+    if surface.name ~= 'nauvis' then
+        return
+    end
     for _, t in pairs(tiles) do
-        if not save_tiles[t.old_tile.name] then
+        if not safe_tiles[t.old_tile.name] then
             surface.set_tiles({ { name = t.old_tile.name, position = t.position } }, true)
-            if prototypes.item[tile.name] then
-                inventory.insert({ name = tile.name, count = 1 })
-            else
-                if tile_to_item[tile.name] then
-                    inventory.insert({ name = tile_to_item[tile.name], count = 1 })
-                else
-                    inventory.insert({ name = 'stone-brick', count = 1 })
-                end
+            local item = tile.items_to_place_this and tile.items_to_place_this[1]
+            if item then
+                inventory.insert(item)
             end
         end
     end
@@ -310,20 +502,8 @@ local function on_player_joined_game(event)
         player.insert({ name = 'stone', count = 5 })
         player.insert({ name = 'pistol', count = 1 })
         player.insert({ name = 'firearm-magazine', count = 16 })
-        player.teleport(game.surfaces['desert_oasis'].find_non_colliding_position('character', { 64, 64 }, 50, 0.5), 'desert_oasis')
+        player.teleport(game.surfaces.nauvis.find_non_colliding_position('character', { 64, 64 }, 50, 0.5) or {64, 64}, 'nauvis')
     end
-
-    if game.tick > 0 then
-        return
-    end
-    local p = game.surfaces['desert_oasis'].find_non_colliding_position('stone', { 80, 80 }, 50, 0.5)
-    if not p then
-        return
-    end
-    local e = game.surfaces.desert_oasis.create_entity({ name = 'crash-site-spaceship', position = p, force = 'player', create_build_effect_smoke = false })
-    e.insert({ name = 'repair-pack', count = 2 })
-    e.insert({ name = 'water-barrel', count = 5 })
-    e.minable = false
 end
 
 local function on_player_changed_position(event)
@@ -331,9 +511,14 @@ local function on_player_changed_position(event)
         return
     end
     local player = game.players[event.player_index]
+    local surface = player.physical_surface
 
-    local moisture = get_moisture(player.position)
+    local moisture = get_moisture(surface, player.physical_position)
     moisture_meter(player, moisture)
+
+    if player.controller_type == defines.controllers.remote then
+        return
+    end
 
     if not player.character then
         return
@@ -345,17 +530,15 @@ local function on_player_changed_position(event)
         return
     end
 
-    if save_tiles[player.surface.get_tile(player.position).name] then
+    if safe_tiles[surface.get_tile(player.physical_position.x, player.physical_position.y).name] then
         return
     end
-
-    if math_random(1, 64) == 1 then
-        player.surface.create_entity({ name = 'fire-flame', position = player.position })
-    end
-
-    player.character.health = player.character.health - (sand_damage - moisture) * 0.60
-    if player.character.health == 0 then
-        player.character.die()
+    if moisture <= 40 then
+        if math_random(1, math.max(1, math.min(40, math.floor(moisture)))) == 1 then
+            surface.create_entity({ name = 'fire-flame', position = player.physical_position })
+        end
+        local damage = (sand_damage - moisture)
+        player.character.damage(damage, 'neutral', 'fire')
     end
 end
 

--- a/maps/desert_oasis.lua
+++ b/maps/desert_oasis.lua
@@ -395,6 +395,8 @@ local function on_init()
     surface.request_to_generate_chunks({ 0, 0 }, 3)
     surface.force_generate_chunk_requests()
     surface.set_property('solar-power', 200)
+    local force = game.forces.player
+    force.technologies['cliff-explosives'].enabled = false
 end
 
 local type_whitelist = {

--- a/maps/desert_oasis.lua
+++ b/maps/desert_oasis.lua
@@ -7,11 +7,9 @@ local Map_info = require 'modules.map_info'
 local FT = require 'utils.functions.flying_texts'
 
 local get_noise = require 'utils.math.get_noise'
-local table_insert = table.insert
 local math_random = math.random
 local math_floor = math.floor
 local math_abs = math.abs
-local string_sub = string.sub
 
 local oasis_start = 0.50
 local water_start = 0.81
@@ -70,7 +68,7 @@ local function calculate_gleba(surface, position)
     return moisture
 end
 
-local function calculate_aquilo(surface, position)
+local function calculate_aquilo(_surface, _position)
     local moisture = 45
     return moisture
 end
@@ -377,7 +375,7 @@ local function on_init()
 
     storage.desert_oasis_seed = 0
     local noise
-    local seed = 0
+    local seed
     local position = { x = 0, y = 0 }
     for _ = 1, 1024 ^ 2, 1 do
         seed = math_random(1, 999999999)


### PR DESCRIPTION
- Updated Desert Oasis scenario fully for 2.0 
- Compatible with or without Space Age now
- Changed worldgen for Nauvis to be compatible with 2.0 and also with Space Age
- slightly buffed resources (please don't expand the map too much)
- Added shallow water to make possible bathing :)
- Added decoration into the desert so it looks like super nice desert
- Cliffs for 2.0 were fun to deal with but they work somehow
- Enabled landfill (required for SA, and it is possible to dig it back into water now, so it is safe to have it, but shallow water can't be landfilled for some reason in 2.0)
- Added all new rails and elevated rails as allowed in desert
- Flying texts are using the new system for 2.0
- remote view doesn't count as player movement
- Damage for being in hot desert is more harsh, however having better armors reduces it, and shields do work
- Vulcanus lava fields work same as hot desert -> they hurt 
- Updated Thirst module for 2.0 and using tokening
- Thirst module now has more granularity in values
- Different planets make you thirsty differently (changeable in storage table) - need to drink more on Vulcanus than on Gleba
- Can drink from shallow water
- some fixes
