### PR TITLE
Fix bug with locomotive and armor modded

### DIFF
--- a/maps/mountain_fortress_v3/locomotive.lua
+++ b/maps/mountain_fortress_v3/locomotive.lua
@@ -34,7 +34,11 @@ local valid_armors =
 {
     ['modular-armor'] = true,
     ['power-armor'] = true,
-    ['power-armor-mk2'] = true
+    ['power-armor-mk2'] = true,
+    ['power-armor-mk3'] = true,
+    ['power-armor-mk4'] = true,
+    ['power-armor-mk5'] = true
+
 }
 
 local non_valid_vehicles =


### PR DESCRIPTION
### All Submissions:

- [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Tested Changes:

1. [X] Have you lint your code (lua lint) locally prior to submission?

### Changes to Core Features:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully ran tests with your changes locally?

### Comments

There are a bug with armor MK 3, MK 4 and MK5 with the mod [Mountain Fortress Addons](https://mods.factorio.com/mod/MtnFortressAddons). When we enter in locomotive, we can drive with the armor from this mod, and not to be supposed (like MK1 & MK2). 
